### PR TITLE
chore(ci,deps): redesign PR gate, group dependabot, polish v0.1.2 deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: monday
       time: "09:00"
       timezone: America/Chicago
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     labels:
       - dependencies
     commit-message:
@@ -22,6 +22,23 @@ updates:
       # @types/node tracks the Node runtime target. Allow minor/patch only.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+    groups:
+      # Production deps: bundle patch+minor only. Major bumps escape the group
+      # and open as individual PRs so a human reviews them.
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+      # Dev-tool patch/minor/major bumps go into one PR; these are auto-merged
+      # by .github/workflows/dependabot-automerge.yml once CI passes.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+          - major
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -29,9 +46,18 @@ updates:
       day: monday
       time: "09:30"
       timezone: America/Chicago
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels:
       - dependencies
     commit-message:
       prefix: ci
       include: scope
+    groups:
+      # All actions in one PR. Patch+minor auto-merged; majors escape for review.
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - patch
+          - minor
+          - major

--- a/.github/workflows/ci-cross-platform.yml
+++ b/.github/workflows/ci-cross-platform.yml
@@ -1,0 +1,49 @@
+name: ci-cross-platform
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  ci-macos:
+    name: ci (macos-14)
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci --prefer-offline --no-audit --no-fund
+      - run: npm run ci
+
+      - name: file or update flake-tracking issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -e
+          existing=$(gh issue list --state open --search 'in:title "ci-cross-platform failure tracking"' --json number --jq '.[0].number')
+          ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          body="Failed on \`$SHA\` ($ts): $RUN_URL"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "ci-cross-platform failure tracking" --body "$body"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -15,13 +16,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
-    name: ci (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-14]
-    runs-on: ${{ matrix.os }}
+  lint:
+    if: github.event.pull_request.draft != true
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci --prefer-offline --no-audit --no-fund
+      - run: npm run typecheck
+      - run: npm run lint
+
+  test:
+    if: github.event.pull_request.draft != true
+    name: test
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci --prefer-offline --no-audit --no-fund
+      - run: npm run test
+
+  e2e:
+    if: github.event.pull_request.draft != true
+    name: e2e
+    runs-on: ubuntu-latest
+    needs: test
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -31,5 +64,5 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
-      - run: npm run ci
+      - run: npm ci --prefer-offline --no-audit --no-fund
+      - run: npm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run ci

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,34 @@
+name: dependabot-automerge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge dev-deps and trusted actions bumps
+        if: |
+          steps.meta.outputs.dependency-group == 'dev-dependencies' ||
+          (steps.meta.outputs.dependency-group == 'github-actions' &&
+            (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+             steps.meta.outputs.update-type == 'version-update:semver-minor'))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.2",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "^0.2.119",
+				"@anthropic-ai/claude-agent-sdk": "^0.2.120",
 				"@lmstudio/sdk": "1.5.0",
 				"@mariozechner/pi-agent-core": "0.69.0",
 				"@mariozechner/pi-ai": "0.69.0",
@@ -18,7 +18,7 @@
 				"diff": "^8.0.2",
 				"esbuild": "^0.28.0",
 				"ollama": "0.6.3",
-				"typebox": "^1.1.24",
+				"typebox": "^1.1.33",
 				"undici": "^8.1.0",
 				"uuid": "^14.0.0",
 				"yaml": "^2.6.0"
@@ -27,7 +27,7 @@
 				"clio": "dist/cli/index.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.12",
+				"@biomejs/biome": "^2.4.13",
 				"@types/diff": "^8.0.0",
 				"@types/node": "^22.19.17",
 				"node-pty": "^1.1.0",
@@ -36,13 +36,13 @@
 				"typescript": "^6.0.3"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz",
-			"integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.120.tgz",
+			"integrity": "sha512-4HqVK9SZtlowlpX0LyXX0vlGU9Wkygmgoov/GFya/yMfg89wSECkkkUAwKt7wi3Xg+378QLpDHwiO+cyxYY7NQ==",
 			"license": "SEE LICENSE IN README.md",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.81.0",
@@ -52,23 +52,23 @@
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.120",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.120",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.120",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.120",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.120",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.120",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.120",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.120"
 			},
 			"peerDependencies": {
 				"zod": "^4.0.0"
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz",
-			"integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.120.tgz",
+			"integrity": "sha512-oB6UAXNDGqW3vjTphmDTuQmzSW/VrdHKLLLD8jioshVVN99KfW5ZQ27w+btWLnqOYW7iYdF/EBOuLg2d5rXvsQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -79,9 +79,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.119.tgz",
-			"integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.120.tgz",
+			"integrity": "sha512-ilRxVnWwY9oym0dhVfqPLuH2IFyxzAGQ/n3GY6X/eOKL96niTtqHUV5tu+cprTx2ZioROkFu1I6zi5GQESoakg==",
 			"cpu": [
 				"x64"
 			],
@@ -92,9 +92,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.119.tgz",
-			"integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.120.tgz",
+			"integrity": "sha512-tjVZUIYhjQQM5OzS+SEiDt1KdRm0HlzsDmNbNY1wWjcJfXMepGnJ183p0f8InX5tBfFotCGsiFzWNNORHTAysg==",
 			"cpu": [
 				"arm64"
 			],
@@ -105,9 +105,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.119.tgz",
-			"integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.120.tgz",
+			"integrity": "sha512-uKRkNJlK9PcNJw1UlOnQD0yoTIwRbo7ZC8AOwF7E1Gj3Tvwwef7d8Z1KjSuj9WPum4f8yOLqKEgIE5UniVlT6w==",
 			"cpu": [
 				"arm64"
 			],
@@ -118,9 +118,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.119.tgz",
-			"integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.120.tgz",
+			"integrity": "sha512-H3++eOwVOa02iW/IAIZEWEwBFmDoersA6oxNXAqGnhqI5twYCWFquZu5oear8PMoc3JAhKrxJqi7C3hVxXxJ/Q==",
 			"cpu": [
 				"x64"
 			],
@@ -131,9 +131,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.119.tgz",
-			"integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.120.tgz",
+			"integrity": "sha512-0h/1Eh9vu7QWmO8JoRVS4p36Ldvut5OaUIDUl7xQNYQ8tEdg3PyZPg7vTaS3+IAYWH+WOqCWP59YuhasV5hOXQ==",
 			"cpu": [
 				"x64"
 			],
@@ -144,9 +144,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.119.tgz",
-			"integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.120.tgz",
+			"integrity": "sha512-aig+wXSbJ8/28I1kxz2L0cxgzmaCdwtMQTcg2zzuSa+BE7Ujomnhr/ryC21PYhLzMdgXXgIGTwXU0I8BON5zUw==",
 			"cpu": [
 				"arm64"
 			],
@@ -157,9 +157,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.2.119",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.119.tgz",
-			"integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+			"version": "0.2.120",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.120.tgz",
+			"integrity": "sha512-ViESybhqCXI8aq2NaE/U08i2wW4tYVrYMt+KVN+a5+lyqbsaYDHTvaizYU0wOoKBVJuXOWDQaBmsCdiBTkdZOw==",
 			"cpu": [
 				"x64"
 			],
@@ -970,9 +970,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
-			"integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+			"integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -986,20 +986,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.12",
-				"@biomejs/cli-darwin-x64": "2.4.12",
-				"@biomejs/cli-linux-arm64": "2.4.12",
-				"@biomejs/cli-linux-arm64-musl": "2.4.12",
-				"@biomejs/cli-linux-x64": "2.4.12",
-				"@biomejs/cli-linux-x64-musl": "2.4.12",
-				"@biomejs/cli-win32-arm64": "2.4.12",
-				"@biomejs/cli-win32-x64": "2.4.12"
+				"@biomejs/cli-darwin-arm64": "2.4.13",
+				"@biomejs/cli-darwin-x64": "2.4.13",
+				"@biomejs/cli-linux-arm64": "2.4.13",
+				"@biomejs/cli-linux-arm64-musl": "2.4.13",
+				"@biomejs/cli-linux-x64": "2.4.13",
+				"@biomejs/cli-linux-x64-musl": "2.4.13",
+				"@biomejs/cli-win32-arm64": "2.4.13",
+				"@biomejs/cli-win32-x64": "2.4.13"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
-			"integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+			"integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1014,9 +1014,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
-			"integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+			"integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
 			"cpu": [
 				"x64"
 			],
@@ -1031,9 +1031,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
-			"integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+			"integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1048,9 +1048,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
-			"integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+			"integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1065,9 +1065,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
-			"integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+			"integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1082,9 +1082,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
-			"integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+			"integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1099,9 +1099,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
-			"integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+			"integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1116,9 +1116,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
-			"integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
+			"version": "2.4.13",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+			"integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
 			"cpu": [
 				"x64"
 			],
@@ -6292,9 +6292,9 @@
 			}
 		},
 		"node_modules/typebox": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.31.tgz",
-			"integrity": "sha512-bFTa/YRd11e9a+C+hBlUSmD3DnDRnkcHqaUWX4zoq3q4u5WLnuLPc7yLpO5dRO7Z9VPXcm/GzFkvrH5FkDobeg==",
+			"version": "1.1.33",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.33.tgz",
+			"integrity": "sha512-+/MWwlQ1q2GSVwoxi/+u5JsHkgLQKcCN2Nsjree9c+K7GJu40qbaHrFETmfV1i9Fs1TcOVfynW+jJvIWcXtvjw==",
 			"license": "MIT"
 		},
 		"node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"url": "git+https://github.com/iowarp/clio-coder.git"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=22.0.0"
 	},
 	"bin": {
 		"clio": "dist/cli/index.js"
@@ -72,7 +72,7 @@
 		"prepublishOnly": "npm run typecheck && npm run lint && npm run build && node scripts/check-dist.mjs"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.119",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.120",
 		"@lmstudio/sdk": "1.5.0",
 		"@mariozechner/pi-agent-core": "0.69.0",
 		"@mariozechner/pi-ai": "0.69.0",
@@ -81,13 +81,13 @@
 		"diff": "^8.0.2",
 		"esbuild": "^0.28.0",
 		"ollama": "0.6.3",
-		"typebox": "^1.1.24",
+		"typebox": "^1.1.33",
 		"undici": "^8.1.0",
 		"uuid": "^14.0.0",
 		"yaml": "^2.6.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.12",
+		"@biomejs/biome": "^2.4.13",
 		"@types/diff": "^8.0.0",
 		"@types/node": "^22.19.17",
 		"node-pty": "^1.1.0",


### PR DESCRIPTION
## Summary

This PR consolidates the v0.1.2 dependency polish (CI Node bump + 5 dependabot patches) and a CI redesign that targets sustained throughput for a community-driven repo.

## CI redesign

### `ci.yml` — PR gate, Ubuntu only, fail-fast

Three sequenced jobs, each ~30-60s:

```
lint  -> typecheck + biome      (~30s)
test  -> unit + integration     (~60s)  needs: lint
e2e   -> build + pty e2e        (~30s)  needs: test
```

Drafts skip every job. Concurrency cancel-in-progress prunes superseded pushes. Lint failure now reports in 30s instead of 2m37s.

### `ci-cross-platform.yml` — macOS post-merge + nightly

Full matrix on push to main and a 03:00 UTC nightly. Failures open or comment on a single `ci-cross-platform failure tracking` issue, so macOS regressions are surfaced without blocking PR throughput.

### `dependabot.yml` — group aggressively

| ecosystem | grouping | semver |
|-----------|----------|--------|
| npm prod  | one PR | patch + minor (majors escape) |
| npm dev   | one PR | patch + minor + major |
| actions   | one PR | patch + minor + major |

PR caps trimmed from 5+3 to 3+1. `pi-mono` packages and `@types/node` major bumps remain ignored.

### `dependabot-automerge.yml` — trust dev tools

After CI passes, auto-approve and squash-merge:

- `dev-dependencies` group, any semver level
- `github-actions` group, patch or minor only

Production deps and major bumps still require human review (the **tight** policy you confirmed).

## Polish bumps in this PR

- CI runner: Node 20 to 24
- `engines.node`: `>=20.0.0` to `>=22.0.0`
- `actions/checkout`: v4 to v6 (supersedes #1)
- `actions/setup-node`: v4 to v6 (supersedes #2)
- `@biomejs/biome`: 2.4.12 to 2.4.13 (supersedes #4)
- `typebox`: 1.1.31 to 1.1.33 (supersedes #5)
- `@anthropic-ai/claude-agent-sdk`: 0.2.119 to 0.2.120 (supersedes #8)

## Verification

`npm run ci` clean on Node 24 locally: typecheck ok, lint clean (367 files), 587/587 unit tests, build ok, 40/40 e2e tests. Ubuntu CI on the previous push of this branch was green.

## Manual follow-ups (after merge)

1. Apply branch protection on `main`: required checks `lint`, `test`, `e2e`; disallow force-push; require linear history; macOS check informational.
2. Close superseded dependabot PRs #1, #2, #4, #5, #8.
3. File flake-tracking issues for macOS `harness-index` hot-swap race and `termination.test.ts` Node-22 pending-promise pattern.