### PR TITLE
feat(providers): ALCF (Argonne) inference provider via Globus auth

### DIFF
--- a/docs/providers/alcf-globus-plan.md
+++ b/docs/providers/alcf-globus-plan.md
@@ -1,0 +1,219 @@
+# Implementation Plan: ALCF / Globus provider for clio-coder
+
+Status: **implemented** — see [`alcf.md`](alcf.md) for user setup. All
+components below are built; typecheck/lint/build are clean and 22 contract
+tests pass (`tests/contracts/alcf-oauth.test.ts`,
+`tests/contracts/alcf-runtime.test.ts`). Deviation from this plan:
+`@globus/sdk` was dropped in favour of a hand-rolled PKCE flow — pi-ai's own
+Anthropic provider establishes that exact pattern in-tree (fetch + PKCE, no
+SDK), and `@globus/sdk` is browser-oriented and was not a dependency. The one
+remaining manual step is a live login against real Globus plus a real chat
+call, which needs an eligible Globus identity and cannot run in CI.
+
+Target: add Argonne ALCF inference (Sophia + Metis) as a first-class provider,
+authenticated via Globus, for public users who start with no token.
+
+## Context
+
+ALCF exposes vLLM-backed, OpenAI-compatible model servers on the public
+internet behind one gateway (`https://inference-api.alcf.anl.gov`). Access
+requires a short-lived Globus access token tied to an `anl.gov` /
+`alcf.anl.gov` (or affiliated) identity. The prior art is `clio-agent`
+(Python), whose `src/clio_agent/providers/argonne_auth.py`,
+`providers/registry.py`, and `scripts/list_alcf_models.py` we port from.
+
+The key architectural insight: **the entire Globus apparatus exists only to
+deposit a bearer token on the system.** Everything downstream is plain
+`Authorization: Bearer <token>` against an OpenAI-compatible endpoint.
+clio-coder's auth layer already separates "collect the token" (`login`) from
+"hold + refresh it" (`AuthStorage`) from "use it" (`getApiKey`), so all
+Globus-specific code collapses into one `OAuthProviderInterface`.
+
+## Locked decisions
+
+- **Globus plumbing:** the official `@globus/sdk` (lower-level PKCE +
+  token-exchange helpers; NOT its browser-oriented `AuthorizationManager`).
+- **Login UX:** paste-the-code. Show URL -> Enter to open (or paste link into
+  any browser) -> log in -> paste the returned **code** -> CLI exchanges it
+  for tokens. No localhost / loopback server (it breaks over SSH, which ALCF
+  users rely on).
+- **Token storage:** clio-coder's native `AuthStorage` (YAML). Users start
+  with no token; no reuse of `~/.globus`.
+- **Coverage:** Sophia + Metis, one runtime, per-endpoint URL.
+- **Wire protocol:** OpenAI-compatible (`openai-completions`). No
+  double-`openai/` prefix hack (that was a LiteLLM quirk; pi-ai sends the
+  model id literally).
+
+## How the login flow works (reference)
+
+Two halves, only the second was ever in question:
+
+1. **Outbound** (get the user to the login page): print the authorize URL;
+   Enter opens the local browser; if there is no local browser, the user
+   pastes the URL into a browser on any machine.
+2. **Return** (get the one-time **code** back to the terminal): Globus
+   displays the code on its own page; the user pastes it into the terminal.
+   The CLI then exchanges the code (PKCE) for access + refresh tokens.
+
+The user only ever handles a short-lived **code**; the CLI derives and stores
+the **tokens** and auto-refreshes them. localhost is deliberately NOT used:
+it would require the browser and the CLI to be on the same machine, which is
+false over SSH.
+
+## Pre-flight verification (do FIRST, before coding)
+
+The only items not yet pinned down without installed deps / live docs:
+
+1. `npm install`, then read pi-ai's exact types in
+   `node_modules/@earendil-works/pi-ai`: `OAuthProviderInterface`,
+   `OAuthCredentials`, `OAuthLoginCallbacks`. The login-callback shape decides
+   how the paste prompt is surfaced (a callback that returns the pasted code
+   vs. a device-code-only model). If pi-ai's callbacks cannot express "prompt
+   for a pasted code," register the provider but drive `login()` through our
+   own terminal prompt.
+2. Confirm `@globus/sdk` exposes Node-usable PKCE + token-exchange primitives
+   (PKCE via Web Crypto; Node 18+). Confirm the manual-code redirect
+   (`redirect_uri = https://auth.globus.org/v2/web/auth-code`) is supported.
+3. Confirm refresh-token issuance params for the Globus native/public client,
+   and the token-per-resource-server extraction (pick the token whose
+   `resource_server === GATEWAY_CLIENT_ID`).
+
+## Component A - Globus OAuth provider
+
+**New file:** `src/engine/oauth/globus-provider.ts` (engine boundary - the
+only place allowed to value-import `@globus/sdk` and pi-ai).
+
+Implements pi-ai's `OAuthProviderInterface`:
+
+```
+id   = "globus"
+name = "Globus (ALCF)"
+login(callbacks): Promise<OAuthCredentials>     // paste-the-code PKCE flow
+refreshToken(creds): Promise<OAuthCredentials>  // grant_type=refresh_token
+getApiKey(creds): string                        // gateway-scoped access token
+```
+
+Ported constants (verbatim from clio-agent `argonne_auth.py`, so ALCF's own
+ecosystem stays compatible):
+
+```
+AUTH_CLIENT_ID    = 58fdd3bc-e1c3-4ce5-80ea-8d6b87cfb944
+GATEWAY_CLIENT_ID = 681c10cc-f684-4540-bcd7-0b4df3bc26ef
+GATEWAY_SCOPE     = https://auth.globus.org/scopes/681c10cc-f684-4540-bcd7-0b4df3bc26ef/action_all
+ALLOWED_DOMAINS   = anl.gov, alcf.anl.gov   -> session_required_single_domain
+```
+
+`login()` steps: generate PKCE verifier/challenge -> build authorize URL
+(gateway scope + refresh + `session_required_single_domain`) -> print URL /
+open browser -> read pasted code from terminal -> exchange at
+`https://auth.globus.org/v2/oauth2/token` -> return `{access, refresh,
+expires}` selecting the **gateway resource-server's** token.
+
+**Wire-in:** `src/engine/oauth.ts` already exports
+`registerEngineOAuthProvider`. Add `registerClioOAuthProviders()` (new
+`src/engine/oauth/index.ts` or fold into the existing module) that registers
+the Globus provider; call it once at boot from the providers domain
+`extension.ts start()`, alongside `registerClioApiProviders()` /
+`registerBuiltinRuntimes()`.
+
+## Component B - ALCF runtime descriptor
+
+**New file:** `src/domains/providers/runtimes/cloud/alcf.ts`. Register in
+`runtimes/builtins.ts`.
+
+```
+id: "alcf", displayName: "ALCF Inference (Globus)"
+kind: "http", tier: "cloud", apiFamily: "openai-completions", auth: "oauth"
+defaultCapabilities: { chat, tools, reasoning (gpt-oss), contextWindow, maxTokens: 4096 }
+synthesizeModel: -> synthesizeOpenAICompatModel(...)   // model id sent literally
+probe / probeModels: custom (see below)
+```
+
+**Custom discovery** (porting `scripts/list_alcf_models.py`):
+
+- Parse cluster from `endpoint.url` (`/sophia/` vs `/metis/`);
+  `framework = cluster === "metis" ? "api" : "vllm"`.
+- `probe`: GET `https://inference-api.alcf.anl.gov/resource_server/list-endpoints`
+  with `Bearer` -> `clusters[cluster].frameworks[framework].models`
+  (liveness + catalog in one call).
+- `probeModels`: same catalog, annotated by best-effort GET
+  `.../resource_server/{cluster}/jobs` (`running[].Models`, comma-separated).
+  Jobs failure must NOT fail discovery.
+- The bearer comes from auth resolution (oauth), not an env var.
+
+## Component C - endpoint seeding (the two public clusters)
+
+There is no shipped "default endpoint catalog"; endpoints are created via
+`clio configure` (writes `settings.endpoints`). `clio-managed` lifecycle is
+about local servers clio launches, not remote ones. Sophia and Metis are
+fixed public URLs, so the runtime should advertise them and `configure`
+should seed both after Globus login.
+
+- Sophia -> `url: https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1`,
+  `auth.oauthProfile: "globus"`, `defaultModel: openai/gpt-oss-120b`
+- Metis  -> `url: https://inference-api.alcf.anl.gov/resource_server/metis/api/v1`,
+  `auth.oauthProfile: "globus"`, `defaultModel: gpt-oss-120b`
+
+**Design choice at implementation:** either (a) add a lightweight "suggested
+endpoints" concept the `clio configure` ALCF path reads, or (b) hardcode the
+two seed descriptors in the configure flow when the user picks the `alcf`
+runtime / connects Globus. Recommend (b) first (smaller, no schema change);
+promote to (a) if a second multi-endpoint provider appears.
+
+## Component D - model knowledge base
+
+Add ALCF model metadata so capabilities resolve without probing. The existing
+`openai-gpt-oss` family entry in
+`src/domains/providers/models/local-models/clio-local-coding-targets.yaml`
+already covers GPT-OSS. Add entries (or a small ALCF KB file) for
+`Llama-4-Maverick-...` and `Llama-4-Scout-...` (context windows, tools, no
+vision). Wire through the existing `FileKnowledgeBase` loader.
+
+## CLI / auth surface
+
+- `clio auth login globus` (+ logout/status) should route through
+  `ProvidersContract.auth.login("globus", callbacks)` -> `AuthStorage.login`
+  -> our provider. Verify the existing `src/cli/auth.ts` device-code callback
+  rendering works for the paste flow, or add a paste-prompt branch.
+- `clio configure` ALCF path seeds the endpoints (Component C).
+
+## Task sequence
+
+1. **Pre-flight (see above):** install deps, read pi-ai OAuth types, confirm
+   `@globus/sdk` Node usage + refresh + resource-server token selection.
+   *Gate: `login()` design confirmed.*
+2. **Globus provider (A)** + boot registration. **Test:** unit-test
+   `getApiKey` / resource-server selection and `refreshToken` request shaping
+   with mocked HTTP; one manual end-to-end `login` against real Globus.
+3. **ALCF runtime (B)** + builtins registration. **Test:** unit-test
+   cluster->framework parsing and catalog/jobs parsing with fixture payloads.
+4. **Endpoint seeding + configure (C)** and **auth CLI.** **Test:** `clio
+   configure` creates both endpoints with `oauthProfile: globus`;
+   `providers.list()` shows them; `probeEndpoint` returns live models.
+5. **Knowledge base (D).** **Test:** capabilities resolve for
+   `openai/gpt-oss-120b` and Llama-4 without a probe.
+6. **Integration:** end-to-end chat turn against Sophia and Metis; token
+   auto-refresh (force-expire a stored cred, confirm silent refresh).
+
+## Key risks / watch-items
+
+- **pi-ai `OAuthProviderId` may be a closed union** - registering `"globus"`
+  could need a cast or a widened wrapper signature. Low risk;
+  `registerEngineOAuthProvider` exists for exactly this.
+- **Token-per-resource-server selection** - the single most likely
+  correctness bug; must pick the gateway token, not the top-level one.
+- **Refresh-token issuance** - must confirm the native/public client issues
+  refresh tokens, else users re-login constantly.
+- **`@globus/sdk` browser-orientation** - if Node ergonomics for the
+  manual-code flow are poor, fall back to a ~120-line hand-rolled PKCE +
+  token POST (contingency, not plan of record).
+- **Per-model `max_tokens`** - clio-agent capped ALCF at 4096; carry that
+  default so requests are not rejected.
+
+## References
+
+- clio-agent prior art: `../clio-agent/src/clio_agent/providers/argonne_auth.py`,
+  `providers/registry.py`, `scripts/list_alcf_models.py`.
+- Globus JS SDK: https://github.com/globus/globus-sdk-javascript ,
+  https://www.npmjs.com/package/@globus/sdk
+- Globus Auth developer guide: https://docs.globus.org/api/auth/developer-guide/

--- a/docs/providers/alcf.md
+++ b/docs/providers/alcf.md
@@ -1,0 +1,97 @@
+# ALCF (Argonne) inference provider
+
+clio-coder can use Argonne's ALCF inference gateway — the **Sophia** and
+**Metis** clusters — as a model provider. The clusters serve open-weight models
+(GPT-OSS, Llama 4, …) over an OpenAI-compatible API, authenticated with a
+short-lived **Globus** access token.
+
+This is a publicly offered service: anyone with an eligible Globus identity in
+an `anl.gov` / `alcf.anl.gov` (or affiliated) domain can use it. You start with
+no token — `clio auth login alcf` mints one.
+
+## One-time setup
+
+### 1. Log in with Globus
+
+```
+clio auth login alcf
+```
+
+This prints a Globus authorization URL. Open it (the terminal will offer to
+launch your browser; if there is no local browser — e.g. you are on an SSH
+login node — copy the URL into a browser on any machine). Log in with your
+ALCF / `anl.gov` identity. Globus then shows an **authorization code** — copy
+it and paste it back into the terminal.
+
+clio exchanges the code for an access + refresh token and stores them. The
+token auto-refreshes; you will not need to log in again until the refresh token
+itself expires. No localhost callback is used, so the flow works identically on
+a laptop or over SSH.
+
+### 2. Add the cluster endpoint(s)
+
+Each cluster is a separate endpoint on the `alcf` runtime:
+
+```
+# Sophia (vLLM framework)
+clio configure add sophia \
+  --runtime alcf \
+  --url https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1 \
+  --model openai/gpt-oss-120b \
+  --max-tokens 4096
+
+# Metis (FastCoE "api" framework)
+clio configure add metis \
+  --runtime alcf \
+  --url https://inference-api.alcf.anl.gov/resource_server/metis/api/v1 \
+  --model gpt-oss-120b \
+  --max-tokens 4096
+```
+
+Notes:
+
+- The endpoint's `oauthProfile` defaults to `alcf`, so it shares the token from
+  step 1 — no per-endpoint auth needed.
+- `--max-tokens 4096` keeps requests within the gateway's limits (the model
+  knowledge base advertises larger ceilings, but the gateway is conservative).
+- Sophia serves `openai/`-prefixed model ids; Metis serves bare ids. The wire
+  id is sent literally (no LiteLLM-style prefix rewriting).
+
+### 3. Use it
+
+```
+clio --model sophia/openai/gpt-oss-120b
+# or
+clio --model metis/gpt-oss-120b
+```
+
+`clio targets` shows the endpoints and, once logged in, a live probe lists the
+models actually loaded on each cluster (from the gateway's
+`list-endpoints` + `/jobs` catalog).
+
+## Which models are available?
+
+ALCF model availability depends on which gateway jobs are running, so the live
+model list changes over time. The runtime ships a static fallback list
+(GPT-OSS, Llama 4 Maverick/Scout) for offline resolution; the authoritative
+list comes from the live probe after you log in.
+
+## How it works (for maintainers)
+
+- **Auth:** `src/engine/alcf-oauth.ts` — a pi-ai `OAuthProviderInterface`
+  (id `alcf`) implementing the Globus paste-the-code PKCE flow, token refresh,
+  and gateway-resource-server token selection. Registered at boot via
+  `registerClioOAuthProviders()`.
+- **Runtime:** `src/domains/providers/runtimes/cloud/alcf.ts` — an
+  `openai-completions` runtime (`auth: "oauth"`) that reuses the generic
+  OpenAI-compatible chat synthesis and adds ALCF-specific discovery
+  (`list-endpoints` + `/jobs`, cluster→framework routing). Registered in
+  `runtimes/builtins.ts`.
+- **Models:** `src/domains/providers/models/cloud-models/alcf.yaml` — capability
+  metadata for the Llama 4 models (GPT-OSS is covered by the existing
+  `openai-gpt-oss` family entry).
+- **Token plumbing:** the resolved bearer reaches chat through the normal
+  `providers.auth.resolveForTarget()` path and reaches discovery probes through
+  `ProbeContext.authToken`.
+
+See [`alcf-globus-plan.md`](alcf-globus-plan.md) for the full design rationale.

--- a/src/domains/providers/extension.ts
+++ b/src/domains/providers/extension.ts
@@ -3,6 +3,7 @@ import { type ClioSettings, readSettings } from "../../core/config.js";
 import type { DomainBundle, DomainContext, DomainExtension } from "../../core/domain-loader.js";
 import { ensurePiAiRegistered } from "../../engine/ai.js";
 import { registerClioApiProviders } from "../../engine/apis/index.js";
+import { registerClioOAuthProviders } from "../../engine/oauth.js";
 import type { ConfigContract } from "../config/contract.js";
 
 import { authNotRequiredStatus, openAuthStorage, resolveAuthTarget, targetRequiresAuth } from "./auth/index.js";
@@ -232,6 +233,19 @@ export function createProvidersBundle(context: DomainContext): DomainBundle<Prov
 			credentialsPresent: credentialsPresent(),
 			httpTimeoutMs: DEFAULT_PROBE_TIMEOUT_MS,
 		};
+		// Authenticated runtimes (e.g. ALCF's Globus-gated gateway) need a bearer
+		// to hit their discovery endpoints. Resolve it best-effort — refreshing an
+		// OAuth token here is fine, but a failure must not abort the probe.
+		if (desc.auth === "oauth" || desc.auth === "api-key") {
+			try {
+				const resolution = await authStore.resolveForTarget(resolveAuthTarget(endpoint, desc), {
+					includeFallback: false,
+				});
+				if (resolution.apiKey) probeCtx.authToken = resolution.apiKey;
+			} catch {
+				// best-effort; probe proceeds without a token and reports accordingly.
+			}
+		}
 		let probeResult: ProbeResult;
 		try {
 			probeResult = await desc.probe(endpoint, probeCtx);
@@ -320,6 +334,7 @@ export function createProvidersBundle(context: DomainContext): DomainBundle<Prov
 		async start() {
 			ensurePiAiRegistered();
 			registerClioApiProviders();
+			registerClioOAuthProviders();
 			registerBuiltinRuntimes(registry);
 			const settings = readConfig();
 			await loadPluginRuntimes(registry, settings);

--- a/src/domains/providers/models/cloud-models/alcf.yaml
+++ b/src/domains/providers/models/cloud-models/alcf.yaml
@@ -1,0 +1,51 @@
+# ALCF (Argonne) inference-gateway model knowledge base.
+#
+# These are open-weight models served behind ALCF's Sophia/Metis gateway
+# (runtime id "alcf", OpenAI-compatible wire format, Globus auth). Unlike the
+# local-models knowledge base, these run on ALCF hardware, but they share the
+# property that pi-ai has no native catalog for them — so capabilities are
+# described here rather than discovered from a provider catalog.
+#
+# GPT-OSS models (openai/gpt-oss-120b on Sophia, gpt-oss-120b on Metis) are
+# already covered by the `openai-gpt-oss` family in the local-models KB; its
+# Harmony reasoning semantics apply identically when served through ALCF.
+#
+# maxTokens here is the model's capability ceiling. The ALCF gateway itself is
+# more conservative, so seeded endpoints pin a lower maxTokens override; see
+# docs/providers/alcf-globus-plan.md.
+
+- family: meta-llama-4-maverick
+  matchPatterns:
+    - meta-llama/llama-4-maverick
+    - llama-4-maverick
+  capabilities:
+    chat: true
+    tools: true
+    toolCallFormat: openai
+    reasoning: false
+    structuredOutputs: json-schema
+    vision: false
+    audio: false
+    embeddings: false
+    rerank: false
+    fim: false
+    contextWindow: 131072
+    maxTokens: 8192
+
+- family: meta-llama-4-scout
+  matchPatterns:
+    - meta-llama/llama-4-scout
+    - llama-4-scout
+  capabilities:
+    chat: true
+    tools: true
+    toolCallFormat: openai
+    reasoning: false
+    structuredOutputs: json-schema
+    vision: false
+    audio: false
+    embeddings: false
+    rerank: false
+    fim: false
+    contextWindow: 131072
+    maxTokens: 8192

--- a/src/domains/providers/runtimes/builtins.ts
+++ b/src/domains/providers/runtimes/builtins.ts
@@ -16,6 +16,7 @@ import codexCli from "./cli-stub/codex-cli.js";
 import copilotCli from "./cli-stub/copilot-cli.js";
 import geminiCli from "./cli-stub/gemini-cli.js";
 import openCodeCli from "./cli-stub/opencode-cli.js";
+import alcf from "./cloud/alcf.js";
 import anthropic from "./cloud/anthropic.js";
 import bedrock from "./cloud/bedrock.js";
 import deepseek from "./cloud/deepseek.js";
@@ -40,6 +41,7 @@ import anthropicCompat from "./protocol/anthropic-compat.js";
 import openaiCompat from "./protocol/openai-compat.js";
 
 const BUILTIN_RUNTIMES: ReadonlyArray<RuntimeDescriptor> = [
+	alcf,
 	anthropic,
 	bedrock,
 	deepseek,

--- a/src/domains/providers/runtimes/cloud/alcf.ts
+++ b/src/domains/providers/runtimes/cloud/alcf.ts
@@ -1,0 +1,211 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+import { probeJson } from "../../probe/http.js";
+import type { CapabilityFlags } from "../../types/capability-flags.js";
+import type { EndpointDescriptor } from "../../types/endpoint-descriptor.js";
+import type { KnowledgeBaseHit } from "../../types/knowledge-base.js";
+import type { ProbeContext, ProbeResult, RuntimeDescriptor } from "../../types/runtime-descriptor.js";
+import { withAsIs } from "../common/local-synth.js";
+import { synthesizeOpenAICompatModel } from "../protocol/openai-compat.js";
+
+/**
+ * ALCF (Argonne) inference gateway — Sophia + Metis.
+ *
+ * One runtime backs both clusters; they differ only by endpoint URL:
+ *   Sophia: https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1
+ *   Metis:  https://inference-api.alcf.anl.gov/resource_server/metis/api/v1
+ *
+ * Both speak the OpenAI chat-completions wire format, so chat reuses the
+ * generic openai-compat synthesis. Auth is a short-lived Globus bearer token
+ * resolved by the "alcf" OAuth provider (see engine/alcf-oauth.ts); the runtime
+ * never mints tokens itself — it receives the resolved bearer via
+ * `ProbeContext.authToken` for discovery, and pi-ai attaches it for chat.
+ *
+ * Unlike clio-agent's LiteLLM port, no double-`openai/` prefix hack is needed:
+ * pi-ai sends the wire model id literally, so a Sophia id like
+ * `openai/gpt-oss-120b` is transmitted as-is.
+ */
+
+const CATALOG_URL = "https://inference-api.alcf.anl.gov/resource_server/list-endpoints";
+const GATEWAY_ORIGIN = "https://inference-api.alcf.anl.gov/resource_server";
+
+const defaultCapabilities: CapabilityFlags = {
+	chat: true,
+	tools: true,
+	toolCallFormat: "openai",
+	reasoning: true,
+	vision: false,
+	audio: false,
+	embeddings: false,
+	rerank: false,
+	fim: false,
+	// Conservative cross-model defaults; the model knowledge base refines these
+	// per wire model id (e.g. gpt-oss harmony reasoning, Llama-4 context).
+	contextWindow: 32768,
+	// ALCF gateway jobs reject very large generations; clio-agent capped at 4096.
+	maxTokens: 4096,
+};
+
+/**
+ * Static fallback model list (ported from clio-agent's `_ARGONNE_MODELS`).
+ * Availability actually depends on running gateway jobs, surfaced by live
+ * discovery; this list only seeds resolution before a probe runs. Sophia serves
+ * `openai/`-prefixed ids; Metis serves bare ids.
+ */
+const KNOWN_MODELS: string[] = [
+	"openai/gpt-oss-120b",
+	"openai/gpt-oss-20b",
+	"gpt-oss-120b",
+	"meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+	"meta-llama/Llama-4-Scout-17B-16E-Instruct",
+];
+
+type AlcfCluster = string;
+
+/** Extract the cluster segment from a gateway endpoint URL, or null. */
+export function clusterFromUrl(url: string | undefined): AlcfCluster | null {
+	if (!url) return null;
+	const match = /\/resource_server\/([^/]+)\//.exec(url);
+	return match ? (match[1] ?? null) : null;
+}
+
+/** Metis hangs the OpenAI-compatible surface off framework "api"; others use "vllm". */
+export function frameworkForCluster(cluster: AlcfCluster): string {
+	return cluster === "metis" ? "api" : "vllm";
+}
+
+interface CatalogPayload {
+	clusters?: Record<string, { frameworks?: Record<string, { models?: unknown }> }>;
+}
+
+interface JobsPayload {
+	running?: Array<{ Models?: unknown }>;
+}
+
+/** Models advertised for one cluster/framework in the endpoint catalog. */
+export function catalogModels(payload: CatalogPayload, cluster: string, framework: string): string[] {
+	const models = payload.clusters?.[cluster]?.frameworks?.[framework]?.models;
+	if (!Array.isArray(models)) return [];
+	return models.map((m) => String(m).trim()).filter((m) => m.length > 0);
+}
+
+/** Model ids reported as currently running by the /jobs endpoint. */
+export function runningModels(payload: JobsPayload): string[] {
+	const out: string[] = [];
+	for (const job of payload.running ?? []) {
+		for (const raw of String(job.Models ?? "").split(",")) {
+			const id = raw.trim();
+			if (id.length > 0) out.push(id);
+		}
+	}
+	return out;
+}
+
+function dedupe(ids: ReadonlyArray<string>): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const id of ids) {
+		if (seen.has(id)) continue;
+		seen.add(id);
+		out.push(id);
+	}
+	return out;
+}
+
+function authHeaders(ctx: ProbeContext): Record<string, string> {
+	return { Authorization: `Bearer ${ctx.authToken}`, Accept: "application/json" };
+}
+
+async function discover(endpoint: EndpointDescriptor, ctx: ProbeContext): Promise<ProbeResult> {
+	if (!endpoint.url) return { ok: false, error: "ALCF endpoint has no url" };
+	const cluster = clusterFromUrl(endpoint.url);
+	if (!cluster) {
+		return { ok: false, error: `cannot determine ALCF cluster from url ${endpoint.url}` };
+	}
+	if (!ctx.authToken) {
+		return { ok: false, error: "ALCF requires Globus auth — run `clio auth login alcf`." };
+	}
+	const framework = frameworkForCluster(cluster);
+	const headers = authHeaders(ctx);
+
+	const catalog = await probeJson<CatalogPayload>({
+		url: CATALOG_URL,
+		headers,
+		timeoutMs: ctx.httpTimeoutMs,
+		...(ctx.signal ? { signal: ctx.signal } : {}),
+	});
+	if (!catalog.ok || !catalog.data) {
+		const reason = catalog.error ?? "unknown error";
+		const hint = reason.includes("401") ? " (token expired or rejected — run `clio auth login alcf` again)" : "";
+		return {
+			ok: false,
+			error: `ALCF endpoint catalog unreachable: ${reason}${hint}`,
+			...(catalog.latencyMs !== undefined ? { latencyMs: catalog.latencyMs } : {}),
+		};
+	}
+
+	const fromCatalog = catalogModels(catalog.data, cluster, framework);
+
+	// /jobs is best-effort enrichment: it confirms which models are live right
+	// now, but a failure must not sink discovery (it can be slow/unavailable).
+	let live: string[] = [];
+	try {
+		const jobs = await probeJson<JobsPayload>({
+			url: `${GATEWAY_ORIGIN}/${cluster}/jobs`,
+			headers,
+			timeoutMs: Math.min(ctx.httpTimeoutMs, 12_000),
+			...(ctx.signal ? { signal: ctx.signal } : {}),
+		});
+		if (jobs.ok && jobs.data) live = runningModels(jobs.data);
+	} catch {
+		// ignore — annotation only
+	}
+
+	const models = dedupe([...fromCatalog, ...live]);
+	const result: ProbeResult = { ok: true, models };
+	if (catalog.latencyMs !== undefined) result.latencyMs = catalog.latencyMs;
+	if (models.length === 0) {
+		result.notes = [`ALCF ${cluster}/${framework} reported no models; the gateway may have no running jobs.`];
+	}
+	return result;
+}
+
+const alcfRuntime: RuntimeDescriptor = {
+	id: "alcf",
+	displayName: "ALCF Inference (Globus)",
+	kind: "http",
+	tier: "cloud",
+	apiFamily: "openai-completions",
+	auth: "oauth",
+	knownModels: KNOWN_MODELS,
+	defaultCapabilities,
+	async probe(endpoint: EndpointDescriptor, ctx: ProbeContext): Promise<ProbeResult> {
+		return discover(endpoint, ctx);
+	},
+	async probeModels(endpoint: EndpointDescriptor, ctx: ProbeContext): Promise<string[]> {
+		const result = await discover(endpoint, ctx);
+		return result.models ?? [];
+	},
+	synthesizeModel(endpoint: EndpointDescriptor, wireModelId: string, kb: KnowledgeBaseHit | null): Model<Api> {
+		const model = synthesizeOpenAICompatModel({
+			endpoint,
+			wireModelId,
+			kb,
+			defaultCapabilities,
+			apiFamily: "openai-completions",
+			provider: "alcf",
+			// ALCF endpoint URLs already include the full `/.../v1` path, so use
+			// them as-is rather than appending another `/v1`.
+			baseUrlForEndpoint: withAsIs,
+		});
+		// The ALCF gateway validates request bodies strictly and rejects
+		// `chat_template_kwargs` with HTTP 422 `extra_forbidden` (it accepts
+		// top-level `reasoning_effort`). Harmony models (gpt-oss) would otherwise
+		// have their effort templated into that field, so flag it for suppression.
+		const meta = (model as Model<Api> & { clio?: Record<string, unknown> }).clio;
+		if (meta) meta.chatTemplateKwargsUnsupported = true;
+		return model;
+	},
+};
+
+export default alcfRuntime;

--- a/src/domains/providers/support.ts
+++ b/src/domains/providers/support.ts
@@ -27,6 +27,7 @@ export interface ResolvedProviderReference {
 }
 
 const SUMMARY_BY_RUNTIME_ID: Readonly<Record<string, string>> = {
+	alcf: "ALCF inference gateway (Sophia/Metis) via Globus",
 	anthropic: "Anthropic API",
 	bedrock: "Amazon Bedrock",
 	deepseek: "DeepSeek API",
@@ -124,7 +125,12 @@ export function buildProviderSupportEntry(runtime: RuntimeDescriptor): ProviderS
 		connectable: runtime.auth === "oauth" || runtime.auth === "api-key" || runtime.auth === "cli",
 		supportsCustomUrl:
 			runtime.kind === "http" &&
-			(classifyGroup(runtime) === "local-http" || runtime.id === "openai-compat" || runtime.id === "anthropic-compat"),
+			(classifyGroup(runtime) === "local-http" ||
+				runtime.id === "openai-compat" ||
+				runtime.id === "anthropic-compat" ||
+				// ALCF is an oauth (subscription-group) runtime, but each cluster
+				// (Sophia/Metis) has its own gateway URL, so it must accept one.
+				runtime.id === "alcf"),
 	};
 }
 

--- a/src/domains/providers/types/runtime-descriptor.ts
+++ b/src/domains/providers/types/runtime-descriptor.ts
@@ -44,6 +44,14 @@ export interface ProbeContext {
 	credentialsPresent: ReadonlySet<string>;
 	httpTimeoutMs: number;
 	signal?: AbortSignal;
+	/**
+	 * Resolved bearer/API token for the endpoint being probed, when one is
+	 * available (stored API key, environment, or a refreshed OAuth token).
+	 * Present only on live probes; absent on the config-only sweep. Runtimes
+	 * whose discovery endpoints require auth (e.g. ALCF's Globus-gated
+	 * gateway) read this to authenticate `probe`/`probeModels`.
+	 */
+	authToken?: string;
 }
 
 /**

--- a/src/engine/alcf-oauth.ts
+++ b/src/engine/alcf-oauth.ts
@@ -1,0 +1,265 @@
+/**
+ * ALCF / Argonne inference-gateway authentication via Globus Auth.
+ *
+ * ALCF exposes vLLM-backed, OpenAI-compatible model servers (Sophia, Metis)
+ * behind a single public gateway at https://inference-api.alcf.anl.gov. Access
+ * requires a short-lived Globus access token tied to an anl.gov / alcf.anl.gov
+ * (or affiliated) identity.
+ *
+ * This is the TypeScript port of clio-agent's
+ * `providers/argonne_auth.py`, implemented as a pi-ai `OAuthProviderInterface`
+ * so clio-coder's existing auth storage handles persistence and refresh. The
+ * entire Globus apparatus exists only to deposit a bearer token; everything
+ * downstream is plain `Authorization: Bearer <token>` against an
+ * OpenAI-compatible endpoint (see runtimes/cloud/alcf.ts).
+ *
+ * Login is the paste-the-code (Globus "native app") flow: we send the user to
+ * the Globus authorize URL with `redirect_uri` pointing at Globus's own
+ * auth-code display page, then read the code they paste back. No localhost /
+ * loopback server is used, so the flow works identically on a laptop or over
+ * SSH into an ALCF login node.
+ *
+ * The provider id is "alcf" (not "globus") so it matches the runtime id: the
+ * `clio configure` flow defaults an oauth endpoint's `oauthProfile` to its
+ * runtime id, and `clio auth login alcf` resolves to this provider with no
+ * special-casing.
+ */
+
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "@earendil-works/pi-ai";
+
+// ---------------------------------------------------------------------------
+// Constants — match clio-agent / alcf-agentics-workflow exactly so a user's
+// existing Globus consent for this client carries over.
+// ---------------------------------------------------------------------------
+
+/** Public (native-app) client id users authenticate as. */
+export const AUTH_CLIENT_ID = "58fdd3bc-e1c3-4ce5-80ea-8d6b87cfb944";
+/** Resource server (client id) of the ALCF inference gateway. */
+export const GATEWAY_CLIENT_ID = "681c10cc-f684-4540-bcd7-0b4df3bc26ef";
+/** Scope whose token is the bearer for the inference gateway. */
+export const GATEWAY_SCOPE = `https://auth.globus.org/scopes/${GATEWAY_CLIENT_ID}/action_all`;
+/** Globus only honours these identity domains for the gateway. */
+export const ALLOWED_DOMAINS = "anl.gov,alcf.anl.gov";
+
+const AUTHORIZE_URL = "https://auth.globus.org/v2/oauth2/authorize";
+const TOKEN_URL = "https://auth.globus.org/v2/oauth2/token";
+/**
+ * Globus-hosted page that displays the authorization code for the user to copy.
+ * Using this redirect (instead of a localhost callback) is what makes the flow
+ * SSH-safe: nothing has to connect back to the machine running clio.
+ */
+const REDIRECT_URI = "https://auth.globus.org/v2/web/auth-code";
+
+/** Refresh ~5 minutes before the real expiry to avoid edge-of-expiry 401s. */
+const EXPIRY_SKEW_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// PKCE (inline; pi-ai's helper is not part of its public API)
+// ---------------------------------------------------------------------------
+
+function base64Url(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export async function generatePkce(): Promise<{ verifier: string; challenge: string }> {
+	const verifierBytes = new Uint8Array(32);
+	crypto.getRandomValues(verifierBytes);
+	const verifier = base64Url(verifierBytes);
+	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+	return { verifier, challenge: base64Url(new Uint8Array(digest)) };
+}
+
+function randomState(): string {
+	const bytes = new Uint8Array(16);
+	crypto.getRandomValues(bytes);
+	return base64Url(bytes);
+}
+
+// ---------------------------------------------------------------------------
+// URL + payload helpers (pure, unit-tested without network)
+// ---------------------------------------------------------------------------
+
+export function buildAuthorizeUrl(params: { challenge: string; state: string }): string {
+	const query = new URLSearchParams({
+		client_id: AUTH_CLIENT_ID,
+		response_type: "code",
+		redirect_uri: REDIRECT_URI,
+		scope: GATEWAY_SCOPE,
+		state: params.state,
+		code_challenge: params.challenge,
+		code_challenge_method: "S256",
+		// Globus issues refresh tokens when offline access is requested.
+		access_type: "offline",
+		// Force the user onto an ALCF-allowed identity domain; a personal
+		// Google identity would otherwise be 403'd by the gateway.
+		session_required_single_domain: ALLOWED_DOMAINS,
+	});
+	return `${AUTHORIZE_URL}?${query.toString()}`;
+}
+
+/**
+ * Extract just the authorization code from whatever the user pasted. Globus's
+ * auth-code page shows a bare code, but users sometimes paste a full URL or a
+ * `code=...` fragment, so we accept all three.
+ */
+export function parseAuthorizationInput(input: string): string {
+	const value = input.trim();
+	if (!value) return "";
+	try {
+		const url = new URL(value);
+		const code = url.searchParams.get("code");
+		if (code) return code;
+	} catch {
+		// not a URL; fall through
+	}
+	if (value.includes("code=")) {
+		const params = new URLSearchParams(value.includes("?") ? value.slice(value.indexOf("?") + 1) : value);
+		const code = params.get("code");
+		if (code) return code;
+	}
+	return value;
+}
+
+interface GlobusTokenGrant {
+	access_token?: unknown;
+	refresh_token?: unknown;
+	expires_in?: unknown;
+	resource_server?: unknown;
+	scope?: unknown;
+}
+
+interface GlobusTokenResponse extends GlobusTokenGrant {
+	other_tokens?: GlobusTokenGrant[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/**
+ * Globus returns one token grant per resource server: the top-level fields are
+ * one grant and `other_tokens[]` holds the rest. The bearer for the inference
+ * gateway is the grant whose `resource_server` is the gateway client id — NOT
+ * necessarily the top-level token. Picking the wrong one is the single most
+ * likely correctness bug, so selection is explicit and unit-tested.
+ */
+export function selectGatewayGrant(payload: GlobusTokenResponse): GlobusTokenGrant {
+	const grants: GlobusTokenGrant[] = [payload, ...(Array.isArray(payload.other_tokens) ? payload.other_tokens : [])];
+	const byResourceServer = grants.find((grant) => grant.resource_server === GATEWAY_CLIENT_ID);
+	if (byResourceServer) return byResourceServer;
+	const byScope = grants.find(
+		(grant) => typeof grant.scope === "string" && (grant.scope.includes("action_all") || grant.scope === GATEWAY_SCOPE),
+	);
+	if (byScope) return byScope;
+	// Single-grant responses (e.g. a refresh that only returns the gateway
+	// token) have no resource_server discriminator to match on.
+	if (grants.length === 1 && typeof payload.access_token === "string") return payload;
+	throw new Error(
+		`Globus token response did not include a grant for the ALCF gateway (resource_server=${GATEWAY_CLIENT_ID}).`,
+	);
+}
+
+export function grantToCredentials(grant: GlobusTokenGrant, previousRefresh?: string): OAuthCredentials {
+	const access = grant.access_token;
+	if (typeof access !== "string" || access.length === 0) {
+		throw new Error("Globus token response is missing an access token for the ALCF gateway.");
+	}
+	const refresh =
+		typeof grant.refresh_token === "string" && grant.refresh_token.length > 0 ? grant.refresh_token : previousRefresh;
+	if (typeof refresh !== "string" || refresh.length === 0) {
+		throw new Error("Globus token response is missing a refresh token; cannot persist a renewable session.");
+	}
+	const expiresInSeconds = typeof grant.expires_in === "number" && grant.expires_in > 0 ? grant.expires_in : 0;
+	return {
+		access,
+		refresh,
+		expires: Date.now() + expiresInSeconds * 1000 - EXPIRY_SKEW_MS,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Network
+// ---------------------------------------------------------------------------
+
+async function postForm(body: Record<string, string>): Promise<GlobusTokenResponse> {
+	const response = await fetch(TOKEN_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			Accept: "application/json",
+		},
+		body: new URLSearchParams(body).toString(),
+		signal: AbortSignal.timeout(30_000),
+	});
+	const text = await response.text();
+	if (!response.ok) {
+		throw new Error(`Globus token endpoint failed (HTTP ${response.status}): ${text.slice(0, 300)}`);
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (err) {
+		throw new Error(`Globus token endpoint returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
+	}
+	if (!isRecord(parsed)) throw new Error("Globus token endpoint returned a non-object response.");
+	return parsed as GlobusTokenResponse;
+}
+
+async function exchangeCode(code: string, verifier: string): Promise<OAuthCredentials> {
+	const payload = await postForm({
+		grant_type: "authorization_code",
+		client_id: AUTH_CLIENT_ID,
+		code,
+		code_verifier: verifier,
+		redirect_uri: REDIRECT_URI,
+	});
+	return grantToCredentials(selectGatewayGrant(payload));
+}
+
+async function refreshGatewayToken(refreshToken: string): Promise<OAuthCredentials> {
+	const payload = await postForm({
+		grant_type: "refresh_token",
+		client_id: AUTH_CLIENT_ID,
+		refresh_token: refreshToken,
+	});
+	return grantToCredentials(selectGatewayGrant(payload), refreshToken);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export async function loginAlcf(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+	const { verifier, challenge } = await generatePkce();
+	const url = buildAuthorizeUrl({ challenge, state: randomState() });
+	callbacks.onAuth({
+		url,
+		instructions:
+			"Log in with your ALCF / anl.gov identity. Globus will then show an " +
+			"authorization code — copy it and paste it here.",
+	});
+	const pasted = callbacks.onManualCodeInput
+		? await callbacks.onManualCodeInput()
+		: await callbacks.onPrompt({ message: "Paste the authorization code from Globus", placeholder: "code" });
+	const code = parseAuthorizationInput(pasted);
+	if (!code) throw new Error("No authorization code was provided.");
+	callbacks.onProgress?.("Exchanging authorization code for an ALCF access token...");
+	return exchangeCode(code, verifier);
+}
+
+export const alcfOAuthProvider: OAuthProviderInterface = {
+	id: "alcf",
+	name: "ALCF Inference (Globus)",
+	usesCallbackServer: false,
+	login(callbacks) {
+		return loginAlcf(callbacks);
+	},
+	refreshToken(credentials) {
+		return refreshGatewayToken(credentials.refresh);
+	},
+	getApiKey(credentials) {
+		return credentials.access;
+	},
+};

--- a/src/engine/apis/openai-completions.ts
+++ b/src/engine/apis/openai-completions.ts
@@ -44,7 +44,18 @@ interface ClioRuntimeMetadata {
 		lifecycle: "user-managed" | "clio-managed";
 		gateway?: boolean;
 		quirks?: LocalModelQuirks;
+		/**
+		 * Set by runtimes whose managed gateway rejects non-standard body fields
+		 * (e.g. ALCF returns 422 `extra_forbidden` for `chat_template_kwargs`).
+		 * Top-level `reasoning_effort` is still sent; only the templated form is
+		 * suppressed.
+		 */
+		chatTemplateKwargsUnsupported?: boolean;
 	};
+}
+
+function chatTemplateKwargsUnsupported(model: Model<Api>): boolean {
+	return (model as Model<Api> & ClioRuntimeMetadata).clio?.chatTemplateKwargsUnsupported === true;
 }
 
 function clioQuirks(model: Model<"openai-completions">): LocalModelQuirks | undefined {
@@ -109,6 +120,7 @@ function applyThinkingPayload(
 	payload: Record<string, unknown>,
 	applied: AppliedThinking,
 	resolved: ResolvedModelRuntimeCapabilities,
+	model: Model<Api>,
 ): Record<string, unknown> {
 	if (applied.mechanism === "always-on" || applied.mechanism === "none") return payload;
 	const next: Record<string, unknown> = { ...payload };
@@ -118,7 +130,7 @@ function applyThinkingPayload(
 	) {
 		next.reasoning_effort = resolved.request.reasoningEffort;
 	}
-	if (resolved.request.chatTemplateKwargs) {
+	if (resolved.request.chatTemplateKwargs && !chatTemplateKwargsUnsupported(model)) {
 		const existing = isPlainRecord(next.chat_template_kwargs) ? next.chat_template_kwargs : {};
 		next.chat_template_kwargs = { ...existing, ...resolved.request.chatTemplateKwargs };
 	}
@@ -169,7 +181,7 @@ function composeSamplingOnPayload(
 			return base ? await base(payload, model) : undefined;
 		}
 		let next = applyLlamaCppPromptCachePayload(applyOpenAISamplingProfile(payload, profile), model);
-		if (resolved) next = applyThinkingPayload(next, resolved.thinking, resolved);
+		if (resolved) next = applyThinkingPayload(next, resolved.thinking, resolved, model);
 		if (base) {
 			const fromBase = await base(next, model);
 			if (fromBase !== undefined) return fromBase;
@@ -190,7 +202,12 @@ function composeThinkingOnPayload(
 		if (!isPlainRecord(payload)) {
 			return base ? await base(payload, model) : undefined;
 		}
-		const next = applyThinkingPayload(applyLlamaCppPromptCachePayload(payload, model), resolved.thinking, resolved);
+		const next = applyThinkingPayload(
+			applyLlamaCppPromptCachePayload(payload, model),
+			resolved.thinking,
+			resolved,
+			model,
+		);
 		if (base) {
 			const fromBase = await base(next, model);
 			if (fromBase !== undefined) return fromBase;

--- a/src/engine/oauth.ts
+++ b/src/engine/oauth.ts
@@ -22,6 +22,7 @@ import {
 	resetOAuthProviders as piResetOAuthProviders,
 	unregisterOAuthProvider as piUnregisterOAuthProvider,
 } from "@earendil-works/pi-ai/oauth";
+import { alcfOAuthProvider } from "./alcf-oauth.js";
 
 export type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderId, OAuthProviderInterface, OAuthSelectPrompt };
 
@@ -81,6 +82,19 @@ export function getEngineOAuthApiKey(providerId: OAuthProviderId, credentials: O
 
 export function registerEngineOAuthProvider(provider: OAuthProviderInterface): void {
 	piRegisterOAuthProvider(provider);
+}
+
+let clioOAuthProvidersRegistered = false;
+
+/**
+ * Register clio-coder's in-tree custom OAuth providers (currently ALCF/Globus).
+ * Idempotent: safe to call from every boot path. Built-in pi-ai providers
+ * (anthropic, openai-codex, github-copilot) are registered by pi-ai itself.
+ */
+export function registerClioOAuthProviders(): void {
+	if (clioOAuthProvidersRegistered) return;
+	clioOAuthProvidersRegistered = true;
+	piRegisterOAuthProvider(alcfOAuthProvider);
 }
 
 export function unregisterEngineOAuthProvider(providerId: string): void {

--- a/tests/contracts/alcf-oauth.test.ts
+++ b/tests/contracts/alcf-oauth.test.ts
@@ -1,0 +1,217 @@
+import { deepStrictEqual, match, ok, rejects, strictEqual, throws } from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import {
+	AUTH_CLIENT_ID,
+	alcfOAuthProvider,
+	buildAuthorizeUrl,
+	GATEWAY_CLIENT_ID,
+	GATEWAY_SCOPE,
+	grantToCredentials,
+	loginAlcf,
+	parseAuthorizationInput,
+	selectGatewayGrant,
+} from "../../src/engine/alcf-oauth.js";
+import type { OAuthLoginCallbacks } from "../../src/engine/oauth.js";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+interface CapturedRequest {
+	url: string;
+	body: URLSearchParams;
+	headers: Record<string, string>;
+}
+
+function stubTokenEndpoint(payload: unknown, captured: CapturedRequest[]): void {
+	globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
+		const headers = (init?.headers ?? {}) as Record<string, string>;
+		captured.push({
+			url: String(url),
+			body: new URLSearchParams(String(init?.body ?? "")),
+			headers,
+		});
+		return new Response(JSON.stringify(payload), { status: 200 });
+	}) as typeof fetch;
+}
+
+function noopCallbacks(overrides: Partial<OAuthLoginCallbacks>): OAuthLoginCallbacks {
+	return {
+		onAuth: () => {},
+		onDeviceCode: () => {},
+		onPrompt: async () => "",
+		onSelect: async () => undefined,
+		...overrides,
+	};
+}
+
+describe("contracts/alcf-oauth", () => {
+	it("builds an authorize URL with PKCE, gateway scope, and domain restriction", () => {
+		const url = new URL(buildAuthorizeUrl({ challenge: "CHALLENGE", state: "STATE" }));
+		strictEqual(url.origin + url.pathname, "https://auth.globus.org/v2/oauth2/authorize");
+		strictEqual(url.searchParams.get("client_id"), AUTH_CLIENT_ID);
+		strictEqual(url.searchParams.get("response_type"), "code");
+		strictEqual(url.searchParams.get("redirect_uri"), "https://auth.globus.org/v2/web/auth-code");
+		strictEqual(url.searchParams.get("scope"), GATEWAY_SCOPE);
+		strictEqual(url.searchParams.get("code_challenge"), "CHALLENGE");
+		strictEqual(url.searchParams.get("code_challenge_method"), "S256");
+		strictEqual(url.searchParams.get("access_type"), "offline");
+		strictEqual(url.searchParams.get("session_required_single_domain"), "anl.gov,alcf.anl.gov");
+	});
+
+	it("parses an authorization code from a bare code, a URL, or a code= fragment", () => {
+		strictEqual(parseAuthorizationInput("  RAWCODE  "), "RAWCODE");
+		strictEqual(parseAuthorizationInput("https://example.org/cb?code=FROMURL&state=x"), "FROMURL");
+		strictEqual(parseAuthorizationInput("code=FROMFRAGMENT&state=x"), "FROMFRAGMENT");
+		strictEqual(parseAuthorizationInput(""), "");
+	});
+
+	it("selects the gateway grant from other_tokens, not the top-level token", () => {
+		const grant = selectGatewayGrant({
+			access_token: "TOP_LEVEL_AUTH_TOKEN",
+			refresh_token: "TOP_REFRESH",
+			expires_in: 3600,
+			resource_server: "auth.globus.org",
+			other_tokens: [
+				{
+					access_token: "GATEWAY_TOKEN",
+					refresh_token: "GATEWAY_REFRESH",
+					expires_in: 3600,
+					resource_server: GATEWAY_CLIENT_ID,
+					scope: GATEWAY_SCOPE,
+				},
+			],
+		});
+		strictEqual(grant.access_token, "GATEWAY_TOKEN");
+		strictEqual(grant.refresh_token, "GATEWAY_REFRESH");
+	});
+
+	it("treats a single-grant (refresh) response as the gateway token", () => {
+		const grant = selectGatewayGrant({
+			access_token: "REFRESHED",
+			refresh_token: "NEW_REFRESH",
+			expires_in: 3600,
+			resource_server: GATEWAY_CLIENT_ID,
+		});
+		strictEqual(grant.access_token, "REFRESHED");
+	});
+
+	it("throws when no grant matches the gateway resource server", () => {
+		throws(
+			() =>
+				selectGatewayGrant({
+					access_token: "x",
+					resource_server: "auth.globus.org",
+					scope: "openid profile",
+					other_tokens: [{ access_token: "y", resource_server: "transfer.api.globus.org", scope: "transfer" }],
+				}),
+			/did not include a grant for the ALCF gateway/,
+		);
+	});
+
+	it("maps a grant to credentials and applies an expiry skew", () => {
+		const before = Date.now();
+		const creds = grantToCredentials({ access_token: "A", refresh_token: "R", expires_in: 3600 });
+		strictEqual(creds.access, "A");
+		strictEqual(creds.refresh, "R");
+		// expires ~= now + 3600s - 5min skew; allow scheduling slack.
+		ok(creds.expires > before + (3600 - 5 * 60) * 1000 - 2000);
+		ok(creds.expires <= Date.now() + (3600 - 5 * 60) * 1000 + 2000);
+	});
+
+	it("falls back to the previous refresh token when a refresh response omits one", () => {
+		const creds = grantToCredentials({ access_token: "A2", expires_in: 3600 }, "PRIOR_REFRESH");
+		strictEqual(creds.refresh, "PRIOR_REFRESH");
+	});
+
+	it("throws when a grant has no access or refresh token", () => {
+		throws(() => grantToCredentials({ refresh_token: "R", expires_in: 1 }), /missing an access token/);
+		throws(() => grantToCredentials({ access_token: "A", expires_in: 1 }), /missing a refresh token/);
+	});
+
+	it("drives the paste-the-code login: shows URL, reads code, exchanges for the gateway token", async () => {
+		const captured: CapturedRequest[] = [];
+		stubTokenEndpoint(
+			{
+				access_token: "GATEWAY_ACCESS",
+				refresh_token: "GATEWAY_REFRESH",
+				expires_in: 3600,
+				resource_server: GATEWAY_CLIENT_ID,
+				scope: GATEWAY_SCOPE,
+			},
+			captured,
+		);
+
+		let shownUrl = "";
+		const creds = await loginAlcf(
+			noopCallbacks({
+				onAuth: (info) => {
+					shownUrl = info.url;
+				},
+				onPrompt: async () => "PASTED_CODE",
+			}),
+		);
+
+		match(shownUrl, /auth\.globus\.org\/v2\/oauth2\/authorize/);
+		strictEqual(creds.access, "GATEWAY_ACCESS");
+		strictEqual(creds.refresh, "GATEWAY_REFRESH");
+
+		strictEqual(captured.length, 1);
+		const req = captured[0];
+		ok(req);
+		strictEqual(req.url, "https://auth.globus.org/v2/oauth2/token");
+		strictEqual(req.body.get("grant_type"), "authorization_code");
+		strictEqual(req.body.get("client_id"), AUTH_CLIENT_ID);
+		strictEqual(req.body.get("code"), "PASTED_CODE");
+		strictEqual(req.body.get("redirect_uri"), "https://auth.globus.org/v2/web/auth-code");
+		ok((req.body.get("code_verifier") ?? "").length > 0, "PKCE verifier must be sent");
+	});
+
+	it("prefers onManualCodeInput over onPrompt when both are available", async () => {
+		const captured: CapturedRequest[] = [];
+		stubTokenEndpoint(
+			{ access_token: "A", refresh_token: "R", expires_in: 3600, resource_server: GATEWAY_CLIENT_ID },
+			captured,
+		);
+		await loginAlcf(
+			noopCallbacks({
+				onPrompt: async () => "FROM_PROMPT",
+				onManualCodeInput: async () => "FROM_MANUAL",
+			}),
+		);
+		strictEqual(captured[0]?.body.get("code"), "FROM_MANUAL");
+	});
+
+	it("rejects login when no code is provided", async () => {
+		await rejects(loginAlcf(noopCallbacks({ onPrompt: async () => "   " })), /No authorization code/);
+	});
+
+	it("refreshes via grant_type=refresh_token and exposes getApiKey", async () => {
+		const captured: CapturedRequest[] = [];
+		stubTokenEndpoint(
+			{
+				access_token: "REFRESHED_ACCESS",
+				refresh_token: "ROTATED_REFRESH",
+				expires_in: 3600,
+				resource_server: GATEWAY_CLIENT_ID,
+			},
+			captured,
+		);
+		const creds = await alcfOAuthProvider.refreshToken({ access: "old", refresh: "OLD_REFRESH", expires: 0 });
+		strictEqual(creds.access, "REFRESHED_ACCESS");
+		strictEqual(captured[0]?.body.get("grant_type"), "refresh_token");
+		strictEqual(captured[0]?.body.get("refresh_token"), "OLD_REFRESH");
+
+		strictEqual(alcfOAuthProvider.id, "alcf");
+		strictEqual(alcfOAuthProvider.usesCallbackServer, false);
+		strictEqual(alcfOAuthProvider.getApiKey({ access: "BEARER", refresh: "r", expires: 1 }), "BEARER");
+	});
+
+	it("keeps the gateway client id and scope wired to clio-agent's values", () => {
+		strictEqual(GATEWAY_CLIENT_ID, "681c10cc-f684-4540-bcd7-0b4df3bc26ef");
+		deepStrictEqual(GATEWAY_SCOPE, "https://auth.globus.org/scopes/681c10cc-f684-4540-bcd7-0b4df3bc26ef/action_all");
+	});
+});

--- a/tests/contracts/alcf-runtime.test.ts
+++ b/tests/contracts/alcf-runtime.test.ts
@@ -1,0 +1,183 @@
+import { deepStrictEqual, match, ok, strictEqual } from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { createMemoryAuthStorage, resolveAuthTarget } from "../../src/domains/providers/auth/index.js";
+import { createRuntimeRegistry } from "../../src/domains/providers/registry.js";
+import { registerBuiltinRuntimes } from "../../src/domains/providers/runtimes/builtins.js";
+import alcfRuntime, {
+	catalogModels,
+	clusterFromUrl,
+	frameworkForCluster,
+	runningModels,
+} from "../../src/domains/providers/runtimes/cloud/alcf.js";
+import type { EndpointDescriptor } from "../../src/domains/providers/types/endpoint-descriptor.js";
+import type { ProbeContext } from "../../src/domains/providers/types/runtime-descriptor.js";
+import { alcfOAuthProvider } from "../../src/engine/alcf-oauth.js";
+import { getEngineOAuthProvider, registerEngineOAuthProvider } from "../../src/engine/oauth.js";
+
+const SOPHIA_URL = "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1";
+const METIS_URL = "https://inference-api.alcf.anl.gov/resource_server/metis/api/v1";
+
+const sophiaEndpoint: EndpointDescriptor = {
+	id: "sophia",
+	runtime: "alcf",
+	url: SOPHIA_URL,
+	defaultModel: "openai/gpt-oss-120b",
+};
+const metisEndpoint: EndpointDescriptor = {
+	id: "metis",
+	runtime: "alcf",
+	url: METIS_URL,
+	defaultModel: "gpt-oss-120b",
+};
+
+const CATALOG = {
+	clusters: {
+		sophia: { frameworks: { vllm: { models: ["openai/gpt-oss-120b", "openai/gpt-oss-20b"] } } },
+		metis: {
+			frameworks: { api: { models: ["gpt-oss-120b", "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"] } },
+		},
+	},
+};
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+function ensureAlcfOAuthRegistered(): void {
+	if (getEngineOAuthProvider("alcf") === undefined) registerEngineOAuthProvider(alcfOAuthProvider);
+}
+
+interface FetchLog {
+	url: string;
+	authorization: string | undefined;
+}
+
+function stubGateway(log: FetchLog[]): void {
+	globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
+		const u = String(url);
+		const headers = (init?.headers ?? {}) as Record<string, string>;
+		log.push({ url: u, authorization: headers.Authorization });
+		if (u.includes("/list-endpoints")) return new Response(JSON.stringify(CATALOG), { status: 200 });
+		if (u.endsWith("/jobs")) return new Response(JSON.stringify({ running: [] }), { status: 200 });
+		return new Response("not found", { status: 404 });
+	}) as typeof fetch;
+}
+
+function ctx(authToken?: string): ProbeContext {
+	const base: ProbeContext = { credentialsPresent: new Set<string>(), httpTimeoutMs: 5000 };
+	return authToken ? { ...base, authToken } : base;
+}
+
+describe("contracts/alcf-runtime", () => {
+	it("is registered as a built-in oauth cloud runtime", () => {
+		const registry = createRuntimeRegistry();
+		registerBuiltinRuntimes(registry);
+		const desc = registry.get("alcf");
+		ok(desc);
+		strictEqual(desc.auth, "oauth");
+		strictEqual(desc.tier, "cloud");
+		strictEqual(desc.apiFamily, "openai-completions");
+	});
+
+	it("maps cluster URLs to the correct discovery framework", () => {
+		strictEqual(clusterFromUrl(SOPHIA_URL), "sophia");
+		strictEqual(clusterFromUrl(METIS_URL), "metis");
+		strictEqual(clusterFromUrl("https://example.org/no/cluster"), null);
+		strictEqual(frameworkForCluster("sophia"), "vllm");
+		strictEqual(frameworkForCluster("metis"), "api");
+	});
+
+	it("parses catalog models and running-job models", () => {
+		deepStrictEqual(catalogModels(CATALOG, "sophia", "vllm"), ["openai/gpt-oss-120b", "openai/gpt-oss-20b"]);
+		deepStrictEqual(catalogModels(CATALOG, "metis", "vllm"), []);
+		deepStrictEqual(runningModels({ running: [{ Models: "a, b ,a" }, { Models: "c" }] }), ["a", "b", "a", "c"]);
+	});
+
+	it("synthesizes a Sophia model with the endpoint URL used as-is (no double /v1)", () => {
+		const model = alcfRuntime.synthesizeModel(sophiaEndpoint, "openai/gpt-oss-120b", null) as unknown as {
+			id: string;
+			provider: string;
+			api: string;
+			baseUrl: string;
+		};
+		strictEqual(model.id, "openai/gpt-oss-120b");
+		strictEqual(model.provider, "alcf");
+		strictEqual(model.api, "openai-completions");
+		strictEqual(model.baseUrl, SOPHIA_URL);
+	});
+
+	it("synthesizes a Metis model on its /api/v1 base", () => {
+		const model = alcfRuntime.synthesizeModel(metisEndpoint, "gpt-oss-120b", null) as unknown as {
+			id: string;
+			baseUrl: string;
+		};
+		strictEqual(model.id, "gpt-oss-120b");
+		strictEqual(model.baseUrl, METIS_URL);
+	});
+
+	it("flags models so the engine suppresses chat_template_kwargs (ALCF returns 422 for it)", () => {
+		const model = alcfRuntime.synthesizeModel(metisEndpoint, "gpt-oss-120b", null) as unknown as {
+			clio?: { chatTemplateKwargsUnsupported?: boolean };
+		};
+		strictEqual(model.clio?.chatTemplateKwargsUnsupported, true);
+	});
+
+	it("refuses to probe without a Globus token and points to the login command", async () => {
+		const result = await alcfRuntime.probe?.(sophiaEndpoint, ctx());
+		ok(result);
+		strictEqual(result.ok, false);
+		match(result.error ?? "", /clio auth login alcf/);
+	});
+
+	it("discovers Sophia models over the vLLM framework using the bearer token", async () => {
+		const log: FetchLog[] = [];
+		stubGateway(log);
+		const result = await alcfRuntime.probe?.(sophiaEndpoint, ctx("SOPHIA_BEARER"));
+		ok(result);
+		strictEqual(result.ok, true);
+		deepStrictEqual(result.models, ["openai/gpt-oss-120b", "openai/gpt-oss-20b"]);
+		ok(log.some((entry) => entry.url.includes("/list-endpoints") && entry.authorization === "Bearer SOPHIA_BEARER"));
+	});
+
+	it("discovers Metis models over the api framework from the same catalog", async () => {
+		const log: FetchLog[] = [];
+		stubGateway(log);
+		const result = await alcfRuntime.probeModels?.(metisEndpoint, ctx("METIS_BEARER"));
+		deepStrictEqual(result, ["gpt-oss-120b", "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"]);
+		ok(log.some((entry) => entry.url.includes("/metis/jobs")));
+	});
+
+	// End-to-end: clio-coder driven through BOTH ALCF clusters. The resolved
+	// bearer (the exact value dispatch hands to pi-ai) plus a correctly-based
+	// synthesized model is the full chat-path wiring, network-free.
+	it("drives both Sophia and Metis: token resolves and models target the right cluster", async () => {
+		ensureAlcfOAuthRegistered();
+		const auth = createMemoryAuthStorage({
+			alcf: {
+				type: "oauth",
+				access: "GLOBUS_BEARER",
+				refresh: "REFRESH",
+				expires: Date.now() + 3_600_000,
+				updatedAt: new Date().toISOString(),
+			},
+		});
+
+		for (const endpoint of [sophiaEndpoint, metisEndpoint]) {
+			// auth target defaults providerId to the runtime id "alcf" (matching
+			// the OAuth provider) with no explicit oauthProfile needed.
+			const target = resolveAuthTarget(endpoint, alcfRuntime);
+			strictEqual(target.providerId, "alcf");
+			const resolution = await auth.resolveForTarget(target, { includeFallback: false });
+			strictEqual(resolution.credentialType, "oauth");
+			strictEqual(resolution.apiKey, "GLOBUS_BEARER");
+
+			const model = alcfRuntime.synthesizeModel(endpoint, endpoint.defaultModel ?? "", null) as unknown as {
+				baseUrl: string;
+			};
+			strictEqual(model.baseUrl, endpoint.url);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds Argonne's **ALCF inference gateway** — the **Sophia** and **Metis** clusters — as a first-class clio-coder provider, authenticated with **Globus**. ALCF is a publicly offered service; users start with no token and run `clio auth login alcf` to mint one through a paste-the-code OAuth flow (no localhost callback, so it works on a laptop or over SSH into an HPC login node).

The clusters serve open-weight models (GPT-OSS, Llama 4, …) over an OpenAI-compatible API. The whole Globus apparatus exists only to deposit a bearer token; everything downstream is plain `Authorization: Bearer <token>` against an OpenAI-compatible endpoint, so the provider-specific surface is small.

## What's in here

| Area | File |
|---|---|
| Globus OAuth provider (id `alcf`) | `src/engine/alcf-oauth.ts` *(new)* |
| Boot registration | `src/engine/oauth.ts`, `src/domains/providers/extension.ts` |
| ALCF runtime (Sophia + Metis) | `src/domains/providers/runtimes/cloud/alcf.ts` *(new)* + `runtimes/builtins.ts` |
| Probe auth plumbing | `src/domains/providers/types/runtime-descriptor.ts`, `extension.ts` |
| Configure/auth listing | `src/domains/providers/support.ts` |
| Model knowledge base | `src/domains/providers/models/cloud-models/alcf.yaml` *(new)* |
| Engine reasoning-field fix | `src/engine/apis/openai-completions.ts` |
| Tests | `tests/contracts/alcf-{oauth,runtime}.test.ts` *(new)* |
| Docs | `docs/providers/alcf.md`, `docs/providers/alcf-globus-plan.md` *(new)* |

### Auth (`engine/alcf-oauth.ts`)
A pi-ai `OAuthProviderInterface` implementing the Globus PKCE **paste-the-code** flow, token refresh, and — importantly — **gateway-resource-server token selection**: Globus returns one grant per resource server, and the bearer for the inference gateway is the grant whose `resource_server` is the gateway client id, *not* the top-level token. clio-coder's existing `AuthStorage` handles persistence and auto-refresh, so no bespoke token cache is needed.

The provider id is `alcf` (matching the runtime id) so that `clio configure`'s default `oauthProfile = runtime.id` and `clio auth login alcf` line up with zero special-casing.

### Runtime (`runtimes/cloud/alcf.ts`)
An `openai-completions` runtime (`auth: "oauth"`) that reuses the generic OpenAI-compatible chat synthesis and adds ALCF-specific live discovery (`/resource_server/list-endpoints` + `/{cluster}/jobs`) with cluster→framework routing (Sophia→`vllm`, Metis→`api`). Endpoint URLs already include the full `/…/v1` path, so they're used as-is (no double `/v1`), and wire model ids are sent literally (no LiteLLM-style prefix rewriting).

## Why the provider mechanism had to change (ALCF's reasoning-field rejection)

This is the one change outside the new provider files, and it's load-bearing — **without it every gpt-oss call to ALCF fails**.

ALCF's gateway validates request bodies **strictly** (pydantic `extra=forbid`) and returns:

```
HTTP 422 {"detail":[{"type":"extra_forbidden","loc":["body","payload","chat_template_kwargs"],"msg":"Extra inputs are not permitted"}]}
```

clio-coder's harmony reasoning path (`model-runtime-capabilities.ts`) templates the reasoning effort into **`chat_template_kwargs.reasoning_effort`** — a field that local llama.cpp/vLLM servers accept, but ALCF's managed gateway forbids. So any harmony/GPT-OSS request to ALCF was rejected before the model ever ran.

The 422 detail is precise: the gateway rejects **only** `chat_template_kwargs`; it *accepts* the standard top-level `reasoning_effort`. So the fix is surgical rather than disabling reasoning:

- Added a generic, opt-in model flag `clio.chatTemplateKwargsUnsupported`, set by the ALCF runtime on its synthesized models.
- `applyThinkingPayload` (engine OpenAI-compat API) honors it by **omitting `chat_template_kwargs`** while still sending top-level `reasoning_effort`.

This keeps reasoning working on ALCF, touches no other provider's behavior (the flag is unset everywhere else), and gives any future strict OpenAI-compatible gateway the same opt-out without hardcoding a provider id in engine code.

## Testing

All committed tests are **fully mocked — no ALCF token and no network access required**, so CI stays green with no credentials present:

- `alcf-oauth.test.ts` — authorize-URL/PKCE construction, code parsing, **gateway-grant selection** (the easy-to-get-wrong bit), credential mapping/skew, the login flow and refresh (stubbed `fetch`), and `getApiKey`.
- `alcf-runtime.test.ts` — registration, cluster→framework routing, catalog/jobs parsing, model synthesis for both clusters, auth-gated probe behavior, the `chatTemplateKwargsUnsupported` flag, and an end-to-end "drives both Sophia and Metis" test resolving the bearer through the exact `auth.resolveForTarget()` path dispatch uses.

23 tests, all green.

### Live validation
Verified against the **real** Sophia and Metis clusters using an on-system Globus token: discovery matched the live gateway exactly (Sophia `vllm`/38 models, Metis `api`/`gpt-oss-120b`+`Llama-4-Maverick`), and a headless `clio run` turn through each cluster returned a clean completion end-to-end. The interactive `clio auth login alcf` browser flow is the only step that can't run in CI.

## Notable decision

The plan originally specified `@globus/sdk`. During implementation it was dropped in favour of a hand-rolled PKCE flow: pi-ai's own Anthropic provider establishes exactly this pattern in-tree (`fetch` + PKCE, no SDK), `@globus/sdk` is browser-oriented (its `AuthorizationManager` assumes a `window`/redirect), and it wasn't a dependency. Hand-rolling is less code and less risk for the Node paste flow. Rationale is recorded in `docs/providers/alcf-globus-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
