### PR TITLE
docs(readme): CLIO-CODER.md stays versioned; only .clio-coder/ is gitignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,10 @@ Clio loads a local `CLIO-CODER.md` as generated project context on every session
 `clio-coder context init` grounds a draft in the actual source tree, preserves an
 existing handbook until an explicit replacement action, and can adopt existing
 `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Cursor, and Copilot context with
-provenance and conflict reporting. `CLIO-CODER.md` is a gitignored runtime artifact,
-not canonical repository documentation.
+provenance and conflict reporting. `CLIO-CODER.md` is generated context, not
+canonical repository documentation: it is human-owned and stays versioned in
+your repository, while Clio's runtime state lives in the gitignored
+`.clio-coder/` directory.
 
 Alongside it, `clio-coder context index` builds a structural codewiki that the
 `code_nav` tool navigates, so a model can find a symbol without reading half


### PR DESCRIPTION
While testing `context init` on one of our lab's C++ repos, I noticed the README and the CLI disagree about what happens to `CLIO-CODER.md`. The README says it is "a gitignored runtime artifact", but the tool itself only ever ignores `.clio-coder/` (`bootstrap.ts` writes just that one line), the init message says the handbook "stays versioned and human-owned", and the glossary defines it as "human-owned, version-controlled".

I think the README sentence was describing this repository's own arrangement (this repo does gitignore its dogfooding copy) but, sitting in the product docs, readers naturally apply it to their own projects — where the tool does the opposite. Small thing, but it confused us on first contact, so I reworded the sentence to match what the tool actually does.

Happy to adjust the wording if I misread the intent.

