### PR TITLE
fix(context): drop the exact indexed-file count from the generated handbook

### DIFF
--- a/src/domains/context/bootstrap.ts
+++ b/src/domains/context/bootstrap.ts
@@ -684,20 +684,21 @@ function stabilizeGeneratedOutput(
 
 /**
  * The handbook sections whose every fact is read straight off the codewiki index:
- * how many files it holds, which modules anchor it, where the mass sits. They are
- * the only sections nothing but the index can author, and equally the only ones
- * that are wrong the moment the tree moves, so `context refresh` re-derives them
- * in place and leaves every other section to its human or model author.
+ * which modules anchor it and where the mass sits. They are the only sections
+ * nothing but the index can author, and equally the only ones that are wrong the
+ * moment the tree moves, so `context refresh` re-derives them in place and leaves
+ * every other section to its human or model author. An exact file count stays
+ * out: the handbook persists between refreshes while the tree keeps moving, so a
+ * precise number is falsified by any single added file and carries no
+ * navigational value the entry-point list does not.
  */
 export function codewikiSections(codewiki: Codewiki): ClioMdSection[] {
 	const sections: ClioMdSection[] = [];
 	const entryPoints = codewikiEntryPoints(codewiki, 8);
-	const indexedCount = indexedSourceFileCount(codewiki);
 	if (entryPoints.length > 0) {
 		sections.push({
 			title: "Context retrieval",
 			body: [
-				`The codewiki currently indexes ${indexedCount} source file${indexedCount === 1 ? "" : "s"}.`,
 				`Start orientation with these indexed entry points: ${entryPoints.map((entry) => `\`${entry}\``).join(", ")}.`,
 				"Use `code_nav` (modes: symbol, path, entries, outline, deps, dependents, wiki) before broad reads when the task is navigational.",
 			].join(" "),

--- a/tests/contracts/context-refresh.test.ts
+++ b/tests/contracts/context-refresh.test.ts
@@ -203,11 +203,13 @@ describe("contracts/context-refresh", () => {
 	});
 
 	/**
-	 * The index-owned sections state file counts, entry points and where the mass
-	 * of the tree sits. Those are the only handbook facts nothing but the index can
-	 * author, and the only ones that are wrong the moment a file moves. Refresh
-	 * rebuilds the index anyway, so leaving them stale was leaving the handbook
-	 * confidently wrong about the repository it had just re-read.
+	 * The index-owned sections state entry points and where the mass of the tree
+	 * sits. Those are the only handbook facts nothing but the index can author,
+	 * and the only ones that are wrong the moment a file moves. Refresh rebuilds
+	 * the index anyway, so leaving them stale was leaving the handbook confidently
+	 * wrong about the repository it had just re-read. A handbook that still
+	 * carries the retired exact-count sentence loses it on refresh: the count was
+	 * only ever true at generation time.
 	 */
 	it("re-derives the index-owned handbook sections against the rebuilt codewiki", async () => {
 		const cwd = scratchProject();
@@ -231,7 +233,8 @@ describe("contracts/context-refresh", () => {
 		strictEqual(result.clioMd, "updated");
 		const after = readFileSync(join(cwd, "CLIO-CODER.md"), "utf8");
 		strictEqual(after.includes("4096 source files"), false, after);
-		ok(after.includes(`indexes ${result.codewikiEntries} source file`), after);
+		strictEqual(after.includes("currently indexes"), false, after);
+		ok(after.includes("Start orientation with these indexed entry points:"), after);
 		// Sections the index does not author survive untouched, prose and all.
 		ok(after.includes("`src/index.ts` is the only module a change travels through."), after);
 		ok(after.includes("Keep prose byte-stable across refresh."), after);


### PR DESCRIPTION
Closes #137.

While testing `context init` on one of our repos I noticed the handbook opens with "The codewiki currently indexes N source files." The number is correct at generation time, but the handbook persists while the tree keeps moving, so it drifts almost immediately — this repository's own committed context says 942 files in one place and 927 in another. I know `context refresh` re-derives the section, but that only helps when someone runs it, and the committed artifacts here suggest that in practice the count escapes the refresh cadence.

This feels like the same principle the code already documents for verification commands — a precise claim that can be wrong is worse than a vaguer one that stays true — applied to the always-loaded context: a stale count invites the model to wonder which authority is broken, and it adds nothing the entry-point list doesn't already provide. So this just removes the sentence; the entry points and the `code_nav` guidance stay, and refresh keeps re-deriving them.

Small change: the one template string in `codewikiSections()` plus the refresh contract test. Both affected test files pass (55/55). Happy to rework if you'd rather keep a count in some rounded form.

