### PR TITLE
feat(context): name declared CMake presets in the handbook's verification section

### DIFF
--- a/src/domains/context/bootstrap.ts
+++ b/src/domains/context/bootstrap.ts
@@ -454,6 +454,45 @@ export function packageManager(cwd: string): PackageManager {
 /** A script whose command rewrites the tree cannot serve as a verification gate. */
 const MUTATING_SCRIPT_RE = /(?:^|\s)--(?:fix|write)(?:\s|$)/;
 
+/**
+ * First preset a human could actually invoke: named and not hidden. Hidden
+ * presets exist only to be inherited from, so naming one in the handbook would
+ * hand the agent a command CMake refuses to run.
+ */
+function cmakePresetName(presets: unknown, key: string): string | null {
+	if (typeof presets !== "object" || presets === null || Array.isArray(presets)) return null;
+	const list = (presets as Record<string, unknown>)[key];
+	if (!Array.isArray(list)) return null;
+	for (const entry of list) {
+		if ((entry as Record<string, unknown> | null)?.hidden === true) continue;
+		const name = stringField(entry, "name");
+		if (name !== null) return name;
+	}
+	return null;
+}
+
+/**
+ * CMake presets are the project's own declared configure/build/test recipes,
+ * the same authority package.json scripts carry for Node. A CMake tree without
+ * presets stays silent: nothing there declares a runnable command, and a
+ * guessed `cmake -B build` fails on exactly the toolchain-file and MPI-wrapper
+ * projects this tool targets.
+ */
+function cmakeVerificationLines(cwd: string): string[] {
+	const presets = readJsonFile(join(cwd, "CMakePresets.json"));
+	if (presets === null) return [];
+	const configure = cmakePresetName(presets, "configurePresets");
+	const build = cmakePresetName(presets, "buildPresets");
+	const test = cmakePresetName(presets, "testPresets");
+	const lines: string[] = [];
+	if (configure !== null) {
+		const buildStep = build !== null ? ` then \`cmake --build --preset ${build}\`` : "";
+		lines.push(`Configure with \`cmake --preset ${configure}\`${buildStep}.`);
+	}
+	if (test !== null) lines.push(`Run tests with \`ctest --preset ${test}\`.`);
+	return lines;
+}
+
 function verificationSection(cwd: string): ClioMdSection | null {
 	const scripts = packageScripts(cwd);
 	const pm = packageManager(cwd);
@@ -487,6 +526,7 @@ function verificationSection(cwd: string): ClioMdSection | null {
 	if (hasScript("ci")) {
 		lines.push(`Use ${command("ci")} for the full local gate before committing broad or shared behavior changes.`);
 	}
+	lines.push(...cmakeVerificationLines(cwd));
 	if (lines.length === 0) return null;
 	return { title: "Verification expectations", body: lines.join(" ") };
 }

--- a/tests/contracts/bootstrap.test.ts
+++ b/tests/contracts/bootstrap.test.ts
@@ -84,6 +84,58 @@ describe("contracts/bootstrap", () => {
 		strictEqual(verification.body.includes("`pnpm run format`"), false, verification.body);
 	});
 
+	/**
+	 * CMake presets are the project's own declared configure/build/test recipes,
+	 * so they carry the authority package.json scripts do. A CMake tree without
+	 * presets declares no runnable command, and the section names only declared
+	 * commands: a guessed `cmake -B build` fails on exactly the toolchain-file
+	 * and MPI-wrapper projects this tool targets, which is worse than silence.
+	 */
+	it("names the declared CMake presets as verification commands", async () => {
+		writeFileSync(
+			join(scratch, "CMakeLists.txt"),
+			"cmake_minimum_required(VERSION 3.20)\nproject(fixture CXX)\n",
+			"utf8",
+		);
+		writeFileSync(
+			join(scratch, "CMakePresets.json"),
+			JSON.stringify({
+				version: 6,
+				configurePresets: [
+					{ name: "base", hidden: true, generator: "Ninja" },
+					{ name: "debug", inherits: "base", binaryDir: "build" },
+				],
+				buildPresets: [{ name: "debug", configurePreset: "debug" }],
+				testPresets: [{ name: "debug", configurePreset: "debug" }],
+			}),
+			"utf8",
+		);
+		writeFileSync(join(scratch, "main.cpp"), "int main() { return 0; }\n", "utf8");
+
+		const result = await runBootstrap({ cwd: scratch, confirmGitignore: () => true });
+		const verification = result.output.sections?.find((section) => section.title === "Verification expectations");
+		ok(verification, "a repository with declared presets must get a verification section");
+
+		ok(verification.body.includes("`cmake --preset debug`"), verification.body);
+		ok(verification.body.includes("`cmake --build --preset debug`"), verification.body);
+		ok(verification.body.includes("`ctest --preset debug`"), verification.body);
+		// The hidden preset exists only to be inherited from; CMake refuses to run it.
+		strictEqual(verification.body.includes("base"), false, verification.body);
+	});
+
+	it("stays silent on a CMake tree that declares no presets", async () => {
+		writeFileSync(
+			join(scratch, "CMakeLists.txt"),
+			"cmake_minimum_required(VERSION 3.20)\nproject(fixture CXX)\n",
+			"utf8",
+		);
+		writeFileSync(join(scratch, "main.cpp"), "int main() { return 0; }\n", "utf8");
+
+		const result = await runBootstrap({ cwd: scratch, confirmGitignore: () => true });
+		const verification = result.output.sections?.find((section) => section.title === "Verification expectations");
+		strictEqual(verification, undefined, verification?.body);
+	});
+
 	it("measures the local import extension instead of reading it off the stack", async () => {
 		writeFileSync(
 			join(scratch, "package.json"),


### PR DESCRIPTION
Closes #138.

I ran `context init` on one of our lab's C++ repos and the handbook came out with no build or test guidance at all — `verificationSection()` only reads `package.json` scripts, and in a repo without one it silently returns null. For a tool aimed at scientific C++ codebases that felt worth improving, so this is a small first slice.

It only reads `CMakePresets.json`, because presets are the project's own declared configure/build/test recipes — the same authority package.json scripts carry. When presets exist, the handbook names them (`cmake --preset X`, `cmake --build --preset X`, `ctest --preset X`, skipping hidden presets, which CMake refuses to run). A bare `CMakeLists.txt` deliberately keeps today's behavior (section absent): nothing there declares a runnable command, and following the rule already documented in this file — a command the repo cannot run is worse than none — a guessed `cmake -B build` would fail on exactly the toolchain-file and MPI-wrapper projects Clio targets.

Two contract tests: presets are named (hidden ones excluded), and a preset-less tree stays silent. Typecheck, lint, and the bootstrap contract suite pass (43/43). Related: #139, #140, #141 apply the same declared-commands-only rule to Rust, Go, and Python; each is a separate small PR so they can be judged independently.