### PR TITLE
feat(context): name Cargo toolchain commands in the handbook's verification section

### DIFF
--- a/src/domains/context/bootstrap.ts
+++ b/src/domains/context/bootstrap.ts
@@ -487,6 +487,12 @@ function verificationSection(cwd: string): ClioMdSection | null {
 	if (hasScript("ci")) {
 		lines.push(`Use ${command("ci")} for the full local gate before committing broad or shared behavior changes.`);
 	}
+	// Cargo's commands are defined by the toolchain, not by each project, so
+	// naming them for any Cargo workspace carries the same confidence as a
+	// declared package script.
+	if (existsSync(join(cwd, "Cargo.toml"))) {
+		lines.push("Run `cargo build` and `cargo test` before handoff.");
+	}
 	if (lines.length === 0) return null;
 	return { title: "Verification expectations", body: lines.join(" ") };
 }

--- a/tests/contracts/bootstrap.test.ts
+++ b/tests/contracts/bootstrap.test.ts
@@ -84,6 +84,25 @@ describe("contracts/bootstrap", () => {
 		strictEqual(verification.body.includes("`pnpm run format`"), false, verification.body);
 	});
 
+	/**
+	 * Cargo's commands are defined by the toolchain, not by each project, so a
+	 * Cargo workspace can be handed `cargo build` and `cargo test` with the same
+	 * confidence a declared package script carries. Before this, any repository
+	 * without a package.json got no verification section at all.
+	 */
+	it("names the Cargo toolchain commands for a Rust workspace", async () => {
+		writeFileSync(join(scratch, "Cargo.toml"), '[package]\nname = "fixture"\nversion = "0.1.0"\n', "utf8");
+		mkdirSync(join(scratch, "src"), { recursive: true });
+		writeFileSync(join(scratch, "src", "main.rs"), "fn main() {}\n", "utf8");
+
+		const result = await runBootstrap({ cwd: scratch, confirmGitignore: () => true });
+		const verification = result.output.sections?.find((section) => section.title === "Verification expectations");
+		ok(verification, "a Cargo workspace must get a verification section");
+
+		ok(verification.body.includes("`cargo build`"), verification.body);
+		ok(verification.body.includes("`cargo test`"), verification.body);
+	});
+
 	it("measures the local import extension instead of reading it off the stack", async () => {
 		writeFileSync(
 			join(scratch, "package.json"),


### PR DESCRIPTION
Closes #139.

Same gap as #144, smallest possible slice: `verificationSection()` only reads `package.json` scripts, so a Rust workspace gets no verification guidance in its generated handbook.

Unlike CMake, there is nothing to be careful about here — `cargo build` and `cargo test` are defined by the toolchain itself, not by each project, so naming them for any `Cargo.toml` workspace carries the same confidence as a declared package script. That keeps the rule this file already documents: only name commands the repository can actually run.

One existence check, one line in the section, one contract test. Typecheck, lint, and the bootstrap contract suite pass (42/42). Related: #144 (CMake), #140 (Go), #141 (Python).