### PR TITLE
feat(context): name Go toolchain commands in the handbook's verification section

### DIFF
--- a/src/domains/context/bootstrap.ts
+++ b/src/domains/context/bootstrap.ts
@@ -487,6 +487,12 @@ function verificationSection(cwd: string): ClioMdSection | null {
 	if (hasScript("ci")) {
 		lines.push(`Use ${command("ci")} for the full local gate before committing broad or shared behavior changes.`);
 	}
+	// Go's commands are defined by the toolchain, not by each project, so
+	// naming them for any module carries the same confidence as a declared
+	// package script.
+	if (existsSync(join(cwd, "go.mod"))) {
+		lines.push("Run `go build ./...` and `go test ./...` before handoff.");
+	}
 	if (lines.length === 0) return null;
 	return { title: "Verification expectations", body: lines.join(" ") };
 }

--- a/tests/contracts/bootstrap.test.ts
+++ b/tests/contracts/bootstrap.test.ts
@@ -84,6 +84,24 @@ describe("contracts/bootstrap", () => {
 		strictEqual(verification.body.includes("`pnpm run format`"), false, verification.body);
 	});
 
+	/**
+	 * Go's commands are defined by the toolchain, not by each project, so a Go
+	 * module can be handed `go build ./...` and `go test ./...` with the same
+	 * confidence a declared package script carries. Before this, any repository
+	 * without a package.json got no verification section at all.
+	 */
+	it("names the Go toolchain commands for a Go module", async () => {
+		writeFileSync(join(scratch, "go.mod"), "module example.com/fixture\n\ngo 1.22\n", "utf8");
+		writeFileSync(join(scratch, "main.go"), "package main\n\nfunc main() {}\n", "utf8");
+
+		const result = await runBootstrap({ cwd: scratch, confirmGitignore: () => true });
+		const verification = result.output.sections?.find((section) => section.title === "Verification expectations");
+		ok(verification, "a Go module must get a verification section");
+
+		ok(verification.body.includes("`go build ./...`"), verification.body);
+		ok(verification.body.includes("`go test ./...`"), verification.body);
+	});
+
 	it("measures the local import extension instead of reading it off the stack", async () => {
 		writeFileSync(
 			join(scratch, "package.json"),


### PR DESCRIPTION
Closes #140.

Same gap as #144 and the same shape as #145: `verificationSection()` only reads `package.json` scripts, so a Go module gets no verification guidance in its generated handbook.

`go build ./...` and `go test ./...` are defined by the toolchain, not by each project, so naming them for any `go.mod` module carries the same confidence as a declared package script — keeping the rule this file already documents: only name commands the repository can actually run.

One existence check, one line in the section, one contract test. Typecheck, lint, and the bootstrap contract suite pass (42/42). Related: #144 (CMake), #145 (Rust), #141 (Python).