### PR TITLE
feat(context): name declared Python runners in the handbook's verification section

### DIFF
--- a/src/domains/context/bootstrap.ts
+++ b/src/domains/context/bootstrap.ts
@@ -454,6 +454,30 @@ export function packageManager(cwd: string): PackageManager {
 /** A script whose command rewrites the tree cannot serve as a verification gate. */
 const MUTATING_SCRIPT_RE = /(?:^|\s)--(?:fix|write)(?:\s|$)/;
 
+/**
+ * Python has no single scripts manifest, so the section names a runner only
+ * where the project declares one: a tox configuration declares `tox`, and a
+ * declared pytest configuration declares `pytest`. An undeclared layout stays
+ * silent rather than guessing `python -m unittest` at a repository that tests
+ * some other way. Tox wins when both are declared because it typically wraps
+ * the pytest run.
+ */
+function pythonVerificationLines(cwd: string): string[] {
+	let pyproject = "";
+	try {
+		pyproject = readFileSync(join(cwd, "pyproject.toml"), "utf8");
+	} catch {
+		pyproject = "";
+	}
+	if (existsSync(join(cwd, "tox.ini")) || pyproject.includes("[tool.tox]")) {
+		return ["Run `tox` before handoff."];
+	}
+	if (existsSync(join(cwd, "pytest.ini")) || pyproject.includes("[tool.pytest.ini_options]")) {
+		return ["Run `pytest` before handoff."];
+	}
+	return [];
+}
+
 function verificationSection(cwd: string): ClioMdSection | null {
 	const scripts = packageScripts(cwd);
 	const pm = packageManager(cwd);
@@ -487,6 +511,7 @@ function verificationSection(cwd: string): ClioMdSection | null {
 	if (hasScript("ci")) {
 		lines.push(`Use ${command("ci")} for the full local gate before committing broad or shared behavior changes.`);
 	}
+	lines.push(...pythonVerificationLines(cwd));
 	if (lines.length === 0) return null;
 	return { title: "Verification expectations", body: lines.join(" ") };
 }

--- a/tests/contracts/bootstrap.test.ts
+++ b/tests/contracts/bootstrap.test.ts
@@ -84,6 +84,51 @@ describe("contracts/bootstrap", () => {
 		strictEqual(verification.body.includes("`pnpm run format`"), false, verification.body);
 	});
 
+	/**
+	 * Python has no single scripts manifest, so the section names a runner only
+	 * where the project declares one. A layout that declares nothing stays
+	 * silent rather than being guessed at: a wrong runner in the handbook is
+	 * worse than none.
+	 */
+	it("names the declared pytest runner for a Python project", async () => {
+		writeFileSync(
+			join(scratch, "pyproject.toml"),
+			'[project]\nname = "fixture"\nversion = "0.1.0"\n\n[tool.pytest.ini_options]\ntestpaths = ["tests"]\n',
+			"utf8",
+		);
+		writeFileSync(join(scratch, "main.py"), "def main() -> None: ...\n", "utf8");
+
+		const result = await runBootstrap({ cwd: scratch, confirmGitignore: () => true });
+		const verification = result.output.sections?.find((section) => section.title === "Verification expectations");
+		ok(verification, "a project with declared pytest configuration must get a verification section");
+		ok(verification.body.includes("`pytest`"), verification.body);
+	});
+
+	it("prefers the declared tox environment over pytest", async () => {
+		writeFileSync(
+			join(scratch, "pyproject.toml"),
+			'[project]\nname = "fixture"\nversion = "0.1.0"\n\n[tool.pytest.ini_options]\ntestpaths = ["tests"]\n',
+			"utf8",
+		);
+		writeFileSync(join(scratch, "tox.ini"), "[tox]\nenvlist = py312\n", "utf8");
+		writeFileSync(join(scratch, "main.py"), "def main() -> None: ...\n", "utf8");
+
+		const result = await runBootstrap({ cwd: scratch, confirmGitignore: () => true });
+		const verification = result.output.sections?.find((section) => section.title === "Verification expectations");
+		ok(verification, "a project with a tox configuration must get a verification section");
+		ok(verification.body.includes("`tox`"), verification.body);
+		strictEqual(verification.body.includes("`pytest`"), false, verification.body);
+	});
+
+	it("stays silent on a Python project that declares no runner", async () => {
+		writeFileSync(join(scratch, "pyproject.toml"), '[project]\nname = "fixture"\nversion = "0.1.0"\n', "utf8");
+		writeFileSync(join(scratch, "main.py"), "def main() -> None: ...\n", "utf8");
+
+		const result = await runBootstrap({ cwd: scratch, confirmGitignore: () => true });
+		const verification = result.output.sections?.find((section) => section.title === "Verification expectations");
+		strictEqual(verification, undefined, verification?.body);
+	});
+
 	it("measures the local import extension instead of reading it off the stack", async () => {
 		writeFileSync(
 			join(scratch, "package.json"),


### PR DESCRIPTION
Closes #141.

Last slice of the gap described in #144: `verificationSection()` only reads `package.json` scripts, so Python repositories get no verification guidance in their generated handbook.

Python has no single scripts manifest, so this names a runner only where the project declares one: `tox.ini` (or `[tool.tox]` in `pyproject.toml`) declares `tox`, and declared pytest configuration (`[tool.pytest.ini_options]` or `pytest.ini`) declares `pytest`. Tox wins when both are present, since it typically wraps the pytest run. A project that declares neither stays silent — following the rule this file already documents, a guessed `python -m unittest` at a repo that tests some other way is worse than nothing.

One honest caveat: the pyproject checks are plain substring containment, not TOML parsing, to avoid pulling in a parser for two keys. A table name appearing in a comment or string would false-positive; that felt acceptable for a declared-config check, but happy to switch to real parsing if you'd rather.

Three contract tests: pytest is named, tox wins over pytest, an undeclared layout stays silent. Typecheck, lint, and the bootstrap contract suite pass (44/44). Related: #144 (CMake), #145 (Rust), #146 (Go).